### PR TITLE
I've added two new files to the `/mps_01/` directory to support the o…

### DIFF
--- a/mps_01/Continuation_Prompt_For_MPS_Task.txt
+++ b/mps_01/Continuation_Prompt_For_MPS_Task.txt
@@ -1,0 +1,41 @@
+Hello Jules,
+
+You are picking up an ongoing task to develop and iteratively refine a "Master Prompt Segment" (MPS) framework. This framework is designed to guide a "Planning AI" in generating structured project plans and task prompts for other AI instances.
+
+**Current Iteration's Work Context:**
+*   The primary output of this ongoing effort is being developed within the `/mps_XX/` directory structure (e.g., `/mps_01/`, `/mps_02/`, etc., with the latest iteration being the current focus).
+*   Key deliverables within each iteration folder include:
+    *   `Master_Prompt_Segment.txt`: The core set of instructions for the Planning AI.
+    *   `prompts/Information_Exchange_Protocol.md`: Defines commit message standards.
+    *   `prompts/00_task_launch_plan.md`: A template for user guidance on launching tasks.
+    *   `Example_Usage_Guide.md`: Explains how users should utilize the MPS.
+    *   `HANDOFF_NOTES.md`: Contains a log of significant decisions, changes, and the state of work from previous Jules instances working on THIS MPS refinement task. **Your first step should be to review this file thoroughly.**
+
+**Your Immediate Task:**
+1.  **Review `HANDOFF_NOTES.md` in the latest `/mps_XX/` folder.** This file contains critical information about what the previous Jules instance (and any before it) accomplished, what feedback was incorporated, and what the state of the deliverables was.
+2.  **Review the User's Latest Feedback/Request:** The user (my name is [User's Name]) will provide their latest instructions or feedback immediately following this prompt.
+3.  **Understand the Current State:** Based on `HANDOFF_NOTES.md` and the current files in the latest `/mps_XX/` directory, understand the current version of the MPS framework.
+4.  **Formulate a Plan:** Propose a plan to address the user's latest feedback/request. This might involve modifying existing MPS framework documents, creating new supporting documents, or advising on the usage of the MPS. Your plan should also include a step to update `HANDOFF_NOTES.md`.
+5.  **Seek User Approval:** Present your understanding and your plan to the user for approval before executing.
+6.  **Execute and Iterate:** Upon approval, execute your plan. Remember to adhere to the established conventions (e.g., using the IEP for your own commits if you modify files related to the MPS framework).
+
+**Key Objectives for the MPS Framework (that you are helping to build):**
+The MPS framework itself aims to enable the generation of project plans that are:
+1.  Highly effective at eliminating or mitigating merge conflicts (top priority, potentially through task serialization).
+2.  Easy for end-users and Task AIs to use.
+3.  Highly parallelized where safe.
+4.  Using readable file names.
+5.  Enabling better progress tracking.
+6.  Providing ways to communicate problems/requests between tasks.
+7.  Open to other recommendations for improvements.
+8.  Supportive of AI-automated PR creation.
+
+**Before you finish your session:**
+*   You **must** update the `/mps_XX/HANDOFF_NOTES.md` file. Add a new entry detailing:
+    *   The user feedback/request you addressed.
+    *   A summary of the changes you made to the MPS framework documents.
+    *   The state in which you are leaving the deliverables.
+    *   Any pending items or suggestions for the *next* Jules instance that picks up this task.
+*   Ensure all your deliverables for *this MPS refinement task* are committed appropriately.
+
+The user is looking for your help to continue improving this MPS framework. Please confirm your understanding and ask any clarifying questions before proceeding.

--- a/mps_01/HANDOFF_NOTES.md
+++ b/mps_01/HANDOFF_NOTES.md
@@ -1,0 +1,13 @@
+# HANDOFF NOTES for MPS Framework Development Task
+
+This file is intended for use by Jules AI instances working on the iterative development and refinement of the Master Prompt Segment (MPS) framework.
+
+Each Jules instance concluding a work session on this task should append notes below, detailing:
+- User feedback/requests addressed during its session.
+- A summary of changes made to the MPS framework documents.
+- The state in which deliverables were left.
+- Any pending items or suggestions for the next Jules instance.
+
+---
+*(Future entries will be appended below this line)*
+---


### PR DESCRIPTION
…ngoing development of the MPS framework.

Here's a summary:
- I created `/mps_01/HANDOFF_NOTES.md` so I can log my work on the MPS framework for future reference.
- I created `/mps_01/Continuation_Prompt_For_MPS_Task.txt` to provide a starting point when I resume this MPS development task later.

These files were created based on your request to establish a way to hand off the MPS framework development.

These additions should make it easier for you to continue working on the MPS framework with me over time. The main MPS framework (v2) was saved previously. This update adds support for managing the overall development process.