### PR TITLE
I've finished creating the framework for prompt add-ons and the task …

### DIFF
--- a/mps_01/Base_IEP_Definition.md
+++ b/mps_01/Base_IEP_Definition.md
@@ -1,0 +1,51 @@
+# Base Information Exchange Protocol (Base IEP) Definition v0.1
+
+This document defines the *minimum required fields* for a commit message when a Jules AI instance performs work. Specific tasks or add-ons may require additional structured data to be included in the `Notes-To-Next-Jules:` field.
+
+## Core Commit Message Structure:
+
+When Jules makes a commit, the commit message **must** adhere to the following multi-line format:
+
+```
+Task-ID: [Unique ID of the task being worked on, e.g., "ProjectAlpha-Phase1-Task3"]
+
+Status: [Simple status, e.g., "Completed", "InProgress", "Blocked", "Error"]
+
+Summary: [One-line concise summary of the changes made in this commit.]
+
+Description:
+[Optional: More detailed explanation of changes if the summary is insufficient. Can be multiple lines. Focus on *what* was changed and *why*.]
+
+Files-Changed:
+- [path/to/file1.ext] [Created|Modified|Deleted]
+- [path/to/file2.ext] [Created|Modified|Deleted]
+- [path/to/directory/] [Created|Deleted]
+
+Notes-To-Next-Jules:
+[Any critical information, observations, warnings, or structured data tags (from add-ons) that the next Jules instance picking up this task or a related task needs to know. If no special notes, write "None." This field is where add-ons will often specify their required tags.]
+
+```
+
+## Field Explanations:
+
+*   **`Task-ID:`**: The identifier for the specific task Jules was assigned. This helps in tracking and auditing.
+*   **`Status:`**: A brief indicator of the outcome of the work performed in this commit.
+    *   `Completed`: The specific sub-task or action leading to this commit was finished successfully.
+    *   `InProgress`: The work is ongoing; this commit represents a checkpoint.
+    *   `Blocked`: Jules cannot proceed with this task due to a specific issue (should be explained in `Notes-To-Next-Jules:`).
+    *   `Error`: An error occurred during the execution that prevented completion (should be explained).
+*   **`Summary:`**: A short, clear summary of what was achieved in the commit.
+*   **`Description:`**: (Optional) Used if the summary isn't enough to explain the changes.
+*   **`Files-Changed:`**: A list of files and directories directly affected by the commit, along with the nature of the change (Created, Modified, Deleted). Paths should be relative to the project root.
+*   **`Notes-To-Next-Jules:`**: This is a crucial field for inter-AI communication and for add-on functionality.
+    *   It should contain any context that would be necessary for another AI (or human) to pick up the work.
+    *   **Add-ons will often specify required structured tags here.** For example, an add-on might require `[ADDON_X_METADATA]: <value>`. These tags should be appended to any existing notes in this field.
+
+## Importance of Adherence:
+
+Strict adherence to this Base IEP is vital for:
+*   **Automated Processing:** Tools may parse these commit messages.
+*   **Inter-AI Handoff:** Ensuring the next AI has the context it needs.
+*   **Auditing and Debugging:** Understanding the history of changes.
+
+This Base IEP is designed to be minimal. Task-specific instructions or more comprehensive MPS frameworks may build upon this by requiring additional structured data within the `Notes-To-Next-Jules:` field.

--- a/mps_01/Create_New_Prompt_Addon_Guide.md
+++ b/mps_01/Create_New_Prompt_Addon_Guide.md
@@ -1,0 +1,88 @@
+# Guide for Creating Prompt Add-ons (MPS-like Modules)
+
+## 1. Introduction
+
+This guide provides a methodology for developing "Prompt Add-ons" (also referred to as Master Prompt Segments or MPS-like modules). These add-ons are blocks of instructional text that can be appended to a user's primary prompt to guide an AI instance (e.g., Jules) in performing tasks with specific behaviors, generating particular artifacts, or adhering to defined protocols.
+
+The goal is to create modular, reusable, and clear sets of instructions that enhance the capabilities and reliability of AI task execution. Designing with modularity also aids potential future integration into tools like a "Prompt Creation Webapp."
+
+## 2. Core Principles for Add-on Design
+
+*   **Clear Purpose:** Each add-on must have a single, well-defined purpose. What specific behavior or output should it induce in the AI?
+*   **Explicit Instructions:** Use clear, direct, and unambiguous language. Avoid jargon where possible or define it clearly.
+*   **Modularity:** Design the add-on to be self-contained as much as possible. If it relies on other processes or documents (like a Base IEP), these dependencies should be explicitly stated.
+*   **User-Centricity:** Consider the end-user of the AI that will be guided by your add-on. How will this add-on make the AI's output more useful, reliable, or manageable for them?
+*   **Atomicity (for AI Actions):** Instruct the AI to perform actions in logical, manageable steps.
+*   **Idempotency (where applicable):** If an AI task might be retried, design instructions within the add-on so that re-executing them (or parts of them) on an already partially completed task doesn't cause errors.
+
+## 3. Steps to Develop a New Prompt Add-on
+
+### Step 3.1: Define the Add-on's Purpose and Scope
+
+*   **Objective:** What is the primary goal of this add-on? (e.g., "Instruct an AI to generate a resumable prompt for its current task," or "Guide an AI to perform detailed code reviews according to a checklist.")
+*   **Target AI:** Which type of AI is this add-on for? (e.g., a "Planning AI" that breaks down projects, or a "Task AI" that executes specific development tasks).
+*   **Inputs:** What information does the add-on expect to be present in the user's primary prompt or in the environment?
+*   **Outputs/Artifacts:** What specific files, text, or actions should the AI produce as a direct result of this add-on's instructions? (e.g., a new file, a section in an existing document, a specific commit message format).
+*   **Success Criteria:** How will you know if the add-on is effective?
+
+### Step 3.2: Draft the Add-on Text
+
+This is the core instructional block. Structure it logically.
+
+*   **Opening Directive:** Clearly state that the following text contains special instructions for the AI.
+    *   Example: `[[START OF 'TASK RESUMPTION' ADD-ON: Instructions for AI Task Management]]`
+*   **Core Instructions:** Detail the steps the AI must take.
+    *   Use imperative verbs (e.g., "Create...", "Define...", "Append...", "Ensure...").
+    *   Break down complex instructions into smaller, numbered, or bulleted steps.
+    *   Specify any conditions or triggers for actions.
+*   **Interaction with Other Protocols/Documents (e.g., Base IEP):**
+    *   If the add-on requires the AI to use or extend a common protocol (like a Base Information Exchange Protocol), be explicit.
+    *   **Extending a Base IEP:** A common pattern is to use a small `Base_IEP_Definition.md` that defines core commit message fields. Add-ons can then extend this by instructing the AI to add specific structured tags or data within a general-purpose field like `Notes-To-Next-Jules`.
+        *   Example: "When you perform action X as per this add-on, you must include the following in your commit message under `Notes-To-Next-Jules`: `[ADDON_XYZ_STATUS]: Completed_Action_X_Details`."
+*   **Error Handling/Edge Cases (Optional but Recommended):**
+    *   Briefly consider common failure points and guide the AI on how to react or report them.
+*   **Closing Directive:** Clearly mark the end of the add-on.
+    *   Example: `[[END OF 'TASK RESUMPTION' ADD-ON]]`
+
+### Step 3.3: Design Supporting Artifacts (if any)
+
+*   If your add-on instructs the AI to create specific documents (e.g., a `Resumption_Prompt.txt`, a `Code_Review_Checklist_Report.md`), define the structure and content of these artifacts.
+*   If your add-on relies on a template that the AI should populate, provide this template text within the add-on itself or specify its location.
+
+### Step 3.4: Define Interaction with User-Specified Paths
+
+*   If the add-on's behavior or output locations can be customized by user-provided paths, clearly state:
+    *   What paths the user can specify.
+    *   The default paths if the user doesn't provide them.
+    *   How the AI should use these paths.
+    *   Example: "The Resumption Prompt you generate should be saved to the user-specified 'Task Output Directory'. If not specified, save it as `[Default Path]`."
+
+### Step 3.5: Create an Example Usage Guide for the Add-on
+
+*   **Purpose:** Explain to an end-user (who wants to use your add-on) how to combine it with their primary prompt.
+*   **Content:**
+    *   Briefly explain what the add-on does.
+    *   Show an example of how to append the add-on text to a typical user prompt.
+    *   Describe the expected outcome or behavior from the AI when the add-on is used.
+    *   Detail any user-configurable paths or parameters relevant to this add-on.
+*   Save this as `<YourAddonName>_Usage_Guide.md`.
+
+### Step 3.6: Test and Refine
+
+*   Append your drafted add-on to various test prompts and submit them to an AI instance.
+*   Evaluate the AI's response and output against your success criteria.
+*   Refine the add-on text, supporting artifact definitions, and usage guide based on test results until it performs reliably and clearly.
+
+## 4. Example: Add-on for Task Resumption (Conceptual Outline)
+
+*   **Purpose:** Instruct a Task AI to create a "Resumption Prompt" for its own task.
+*   **Add-on Text Would Include:**
+    *   Instructions to summarize original goal, work done (referencing IEP commits), `_dev_plan.md` state, next steps.
+    *   Instruction on where to save the Resumption Prompt (e.g., user-defined path or default).
+    *   Instruction to log the creation/update of the Resumption Prompt in its commit message (e.g., `[RESUMPTION_PROMPT_STATUS]: Updated at path/to/file`).
+*   **Supporting Artifact:** The Resumption Prompt file format.
+*   **Usage Guide:** How to add this to any task prompt for a Task AI.
+
+## 5. Conclusion
+
+Developing effective Prompt Add-ons requires clear thinking, precise language, and iterative testing. By following this guide, you can create powerful, reusable modules to enhance AI capabilities across a variety of tasks. Remember that future integration into a UI or webapp is a possibility, so clarity, modularity, and well-defined interfaces (even if text-based) are key.

--- a/mps_01/add_ons/task_resumption_addon.txt
+++ b/mps_01/add_ons/task_resumption_addon.txt
@@ -1,0 +1,79 @@
+[[START OF 'TASK_RESUMPTION_ADDON' v0.1: Instructions for AI Task Management]]
+
+**Purpose:** This add-on instructs the AI (Jules) to generate a detailed "Resumption Prompt" for the current task it is working on. This allows the current task to be paused and resumed efficiently by another AI instance (or the same AI at a later time) with minimal context loss.
+
+**Instructions for AI (Jules):**
+
+1.  **Identify Core Task Details:**
+    *   Review your original prompt for this task. Identify and summarize:
+        *   The overall goal of this task.
+        *   The specific deliverables requested.
+    *   Review your `_dev_plan.md` for this task. Note the last completed step and the next planned step(s).
+
+2.  **Summarize Work Completed:**
+    *   Consult your commit history for this task (as per the Base IEP).
+    *   List the key actions you have taken and the files you have created or modified. Reference specific commit IDs where appropriate.
+
+3.  **Specify Output Location for Resumption Prompt:**
+    *   The Resumption Prompt should be saved in a file named `_resumption_prompt.txt` within the primary output directory designated for this task by the user (hereafter referred to as "Task Output Directory").
+    *   If the user did not specify a Task Output Directory, save it in the current working directory of the task.
+
+4.  **Generate the Resumption Prompt Content:**
+    Create the content for `_resumption_prompt.txt` with the following structure:
+
+    ```text
+    # Resumption Prompt for Task: [Original Task Name/Objective from Prompt]
+
+    ## Original Task Goal:
+    [Summary of the overall goal from original prompt]
+
+    ## Original Task Deliverables:
+    [List of specific deliverables from original prompt]
+
+    ## Current Task State (as of [Timestamp]):
+
+    ### Last Completed Step (from _dev_plan.md):
+    [Quote the last completed step]
+
+    ### Next Planned Step(s) (from _dev_plan.md):
+    [Quote the next planned step or steps]
+
+    ### Summary of Work Done So Far:
+    [Bulleted list of key actions and files created/modified, with commit references if available. e.g.,
+    - Created initial project structure (Commit: XXXXXX)
+    - Implemented function Y in file Z.py (Commit: YYYYYY)
+    - Encountered issue: [brief description of issue if any is blocking next step]
+    ]
+
+    ## Files Created/Modified in this Session (relative to project root):
+    [List of file paths created or modified during your work session for this task]
+
+    ## Next Steps for Resuming AI:
+    1.  Review the above context thoroughly.
+    2.  Focus on completing: "[Next Planned Step(s) from _dev_plan.md]"
+    3.  Ensure all original task deliverables are met.
+    4.  Continue to update `_dev_plan.md` and follow the Base IEP for commits.
+    5.  If any blocking issues were noted, address them first.
+
+    ## Original Full Prompt (for reference):
+    [[[
+    [Paste the full original prompt content here. Ensure it's clearly demarcated, perhaps by triple square brackets or similar, to avoid confusion with this resumption prompt's own instructions.]
+    ]]]
+    ```
+
+5.  **Save the Resumption Prompt:**
+    *   Write the content generated in Step 4 to the `_resumption_prompt.txt` file at the location determined in Step 3.
+
+6.  **Update Commit Message (Base IEP Extension):**
+    *   When you commit the creation or update of this `_resumption_prompt.txt`, you **must** extend your commit message as per the Base IEP.
+    *   In the `Notes-To-Next-Jules:` field of your commit message, add the following structured tag:
+        `[TASK_RESUMPTION_PROMPT_STATUS]: Updated_At='[Full path to _resumption_prompt.txt]'`
+    *   Example `Notes-To-Next-Jules:` field:
+        `Notes-To-Next-Jules: Standard notes here. [TASK_RESUMPTION_PROMPT_STATUS]: Updated_At='alpha_project/outputs/_resumption_prompt.txt'`
+
+7.  **Final Action:**
+    *   After saving the `_resumption_prompt.txt` and committing it with the updated message, if your instructions were to "stop and create a resumption prompt", then cease further work on other aspects of the original task.
+
+These instructions are critical for enabling efficient, stateful task handoff. Adhere to them precisely.
+
+[[END OF 'TASK_RESUMPTION_ADDON' v0.1]]

--- a/mps_01/examples/task_resumption_example.md
+++ b/mps_01/examples/task_resumption_example.md
@@ -1,0 +1,142 @@
+# Example Usage: Task Resumption Add-on
+
+This document demonstrates how a user (or another AI) would instruct a Task AI (Jules) to utilize the "Task Resumption Add-on".
+
+## 1. Scenario
+
+A Task AI (Jules) is currently working on a complex task, for example, "Refactor the authentication module for Project Phoenix." The user wants to pause Jules's work and ensure that it can be resumed later with minimal context loss.
+
+## 2. User's Prompt to Jules (Illustrative)
+
+The user would append the `task_resumption_addon.txt` content to their specific task instruction for Jules.
+
+```text
+Hello Jules,
+
+Your current task is to refactor the authentication module for Project Phoenix.
+The key requirements are:
+1.  Implement OAuth2 using the 'authlib' library.
+2.  Ensure all existing unit tests for authentication still pass.
+3.  Update the API documentation in `docs/api/auth.md`.
+4.  The primary output directory for this task is `project_phoenix/auth_module_updates/`.
+
+Before you conclude your current work session, or if I explicitly ask you to pause, you need to prepare for task resumption.
+
+[[START OF 'TASK_RESUMPTION_ADDON' v0.1: Instructions for AI Task Management]]
+
+**Purpose:** This add-on instructs the AI (Jules) to generate a detailed "Resumption Prompt" for the current task it is working on. This allows the current task to be paused and resumed efficiently by another AI instance (or the same AI at a later time) with minimal context loss.
+
+**Instructions for AI (Jules):**
+
+1.  **Identify Core Task Details:**
+    *   Review your original prompt for this task. Identify and summarize:
+        *   The overall goal of this task.
+        *   The specific deliverables requested.
+    *   Review your `_dev_plan.md` for this task. Note the last completed step and the next planned step(s).
+
+2.  **Summarize Work Completed:**
+    *   Consult your commit history for this task (as per the Base IEP).
+    *   List the key actions you have taken and the files you have created or modified. Reference specific commit IDs where appropriate.
+
+3.  **Specify Output Location for Resumption Prompt:**
+    *   The Resumption Prompt should be saved in a file named `_resumption_prompt.txt` within the primary output directory designated for this task by the user (hereafter referred to as "Task Output Directory").
+    *   If the user did not specify a Task Output Directory, save it in the current working directory of the task. (In this example, the user *did* specify: `project_phoenix/auth_module_updates/`)
+
+4.  **Generate the Resumption Prompt Content:**
+    Create the content for `_resumption_prompt.txt` with the following structure:
+
+    ```text
+    # Resumption Prompt for Task: [Original Task Name/Objective from Prompt]
+
+    ## Original Task Goal:
+    [Summary of the overall goal from original prompt]
+
+    ## Original Task Deliverables:
+    [List of specific deliverables from original prompt]
+
+    ## Current Task State (as of [Timestamp]):
+
+    ### Last Completed Step (from _dev_plan.md):
+    [Quote the last completed step]
+
+    ### Next Planned Step(s) (from _dev_plan.md):
+    [Quote the next planned step or steps]
+
+    ### Summary of Work Done So Far:
+    [Bulleted list of key actions and files created/modified, with commit references if available. e.g.,
+    - Created initial project structure (Commit: XXXXXX)
+    - Implemented function Y in file Z.py (Commit: YYYYYY)
+    - Encountered issue: [brief description of issue if any is blocking next step]
+    ]
+
+    ## Files Created/Modified in this Session (relative to project root):
+    [List of file paths created or modified during your work session for this task]
+
+    ## Next Steps for Resuming AI:
+    1.  Review the above context thoroughly.
+    2.  Focus on completing: "[Next Planned Step(s) from _dev_plan.md]"
+    3.  Ensure all original task deliverables are met.
+    4.  Continue to update `_dev_plan.md` and follow the Base IEP for commits.
+    5.  If any blocking issues were noted, address them first.
+
+    ## Original Full Prompt (for reference):
+    [[[
+    [Paste the full original prompt content here. Ensure it's clearly demarcated, perhaps by triple square brackets or similar, to avoid confusion with this resumption prompt's own instructions.]
+    ]]]
+    ```
+
+5.  **Save the Resumption Prompt:**
+    *   Write the content generated in Step 4 to the `_resumption_prompt.txt` file at the location determined in Step 3.
+
+6.  **Update Commit Message (Base IEP Extension):**
+    *   When you commit the creation or update of this `_resumption_prompt.txt`, you **must** extend your commit message as per the Base IEP.
+    *   In the `Notes-To-Next-Jules:` field of your commit message, add the following structured tag:
+        `[TASK_RESUMPTION_PROMPT_STATUS]: Updated_At='[Full path to _resumption_prompt.txt]'`
+    *   Example `Notes-To-Next-Jules:` field:
+        `Notes-To-Next-Jules: Standard notes here. [TASK_RESUMPTION_PROMPT_STATUS]: Updated_At='project_phoenix/auth_module_updates/_resumption_prompt.txt'`
+
+7.  **Final Action:**
+    *   After saving the `_resumption_prompt.txt` and committing it with the updated message, if your instructions were to "stop and create a resumption prompt", then cease further work on other aspects of the original task.
+
+These instructions are critical for enabling efficient, stateful task handoff. Adhere to them precisely.
+
+[[END OF 'TASK_RESUMPTION_ADDON' v0.1]]
+
+Okay, Jules, please proceed with the refactoring task. If you reach a good stopping point, or if you complete the API documentation update (requirement 3), please create/update the resumption prompt and then pause your work on this task.
+```
+
+## 3. Expected AI (Jules) Behavior
+
+1.  **Normal Task Execution:** Jules proceeds with the "Refactor the authentication module" task, making commits according to the `Base_IEP_Definition.md`.
+2.  **Trigger for Resumption Prompt Creation:** When Jules completes the API documentation update (or another defined trigger point is met, or it's explicitly told to pause):
+    *   It will follow the instructions within the `TASK_RESUMPTION_ADDON` block.
+    *   It will create/update the file `project_phoenix/auth_module_updates/_resumption_prompt.txt`.
+3.  **IEP Commit for Resumption Prompt:** The commit Jules makes when saving the `_resumption_prompt.txt` will look something like this:
+
+    ```
+    Task-ID: ProjectPhoenix-AuthRefactor-Main
+
+    Status: InProgress
+
+    Summary: Updated _resumption_prompt.txt with current task state.
+
+    Description:
+    Saved the current task status, including completed work on API documentation,
+    to the resumption prompt as instructed by the TASK_RESUMPTION_ADDON.
+    Preparing to pause work.
+
+    Files-Changed:
+    - project_phoenix/auth_module_updates/_resumption_prompt.txt [Modified]
+
+    Notes-To-Next-Jules:
+    Completed API documentation update. Next step is to verify OAuth2 flow with all grant types. [TASK_RESUMPTION_PROMPT_STATUS]: Updated_At='project_phoenix/auth_module_updates/_resumption_prompt.txt'
+    ```
+4.  **Pausing (if instructed):** Jules will then stop further work on the refactoring task.
+
+## 4. Resuming the Task
+
+When another Jules instance (or the same one later) is tasked to continue:
+*   The primary instruction would be to consult the `project_phoenix/auth_module_updates/_resumption_prompt.txt`.
+*   This prompt provides all necessary context to pick up the work.
+
+This example illustrates how an add-on can be seamlessly integrated into a user's prompt to provide specialized instructions to an AI, leading to the creation of specific, useful artifacts that enhance the overall workflow.


### PR DESCRIPTION
…resumption add-on.

Here's what I did:
*   I created `/mps_01/Create_New_Prompt_Addon_Guide.md`: This guide explains how to develop new prompt add-ons.
*   I created `/mps_01/add_ons/task_resumption_addon.txt`: This add-on helps instruct me to create resumable prompts for tasks.
*   I created `/mps_01/Base_IEP_Definition.md`: This defines a minimal, extensible Base IEP.
*   I created `/mps_01/examples/task_resumption_example.md`: This shows how to use the task resumption add-on.

This addresses your request to create a system for developing other prompt add-ons, including one specifically for task resumption, and to define an extensible Base IEP.

The main MPS framework and these new add-on development guidelines are now available in `/mps_01/`.