### PR TITLE
I've completed the refactoring of the Master Prompt Segment (MPS) as …

### DIFF
--- a/mps_01/content_for_user_Base_IEP.txt
+++ b/mps_01/content_for_user_Base_IEP.txt
@@ -1,0 +1,76 @@
+# Base Information Exchange Protocol (Base IEP)
+
+## 1. Purpose and Philosophy
+
+This document defines the Base Information Exchange Protocol (Base IEP), a minimal, universal set of fields for standardizing Git commit messages. The primary goals of the Base IEP are:
+
+*   **Clarity and Traceability:** Provide a consistent way to understand the purpose and context of every commit.
+*   **Universal Applicability:** Serve as a foundational communication structure for tasks performed by individual AI instances or teams of collaborating AI instances.
+*   **Extensibility:** Allow for specialized information to be added by specific "Prompt Add-ons" or for particular task types without altering the core fields. This ensures the base remains simple while accommodating diverse needs.
+
+The philosophy is to keep the top-level structure lean and rely on a designated free-form field (`Notes-To-Next-Jules`) for structured extensions.
+
+## 2. Core Base IEP Fields
+
+Every commit message **must** adhere to the following core field structure. These fields are considered fundamental for any task.
+
+\`\`\`
+Task-ID: <Unique identifier for the primary task or context this commit relates to. Often the filename of the initiating prompt or a higher-level tracker ID.>
+Status: <Overall status of the Task-ID (or a more specific Sub-Task-ID if provided in Notes-To-Next-Jules) *after* this commit is applied.>
+  Allowed values:
+    - Not-Started: Initial setup, planning, or pre-work for the task.
+    - In-Progress: Active work is ongoing for the task.
+    - Blocked: The task cannot proceed. (Details **must** be in Notes-To-Next-Jules).
+    - In-Review: Work for a significant milestone or the entire task is awaiting review.
+    - Completed: A defined piece of work or the entire task is considered complete and self-tested.
+    - Tested: The work has passed formal testing procedures.
+Summary: <A concise, imperative summary of the commit's primary purpose (max 72 characters). E.g., "Initialize project structure and add README">
+Files-Modified:
+  - path/to/file_1.ext: Brief note on change.
+  - path/to/file_2.ext: Brief note on change.
+  - ... (List key files. Summarize if many, but be clear).
+Notes-To-Next-Jules:
+<This is a multi-line field for detailed explanations, context, rationale, and crucially, for structured extensions defined by Prompt Add-ons or specific task requirements. See Section 3 for extensibility.>
+\`\`\`
+
+## 3. Extensibility Mechanism
+
+The Base IEP is designed to be extended without altering its core fields. Extensions are primarily achieved by defining structured content (e.g., key-value pairs, special tags, Markdown sections) within the `Notes-To-Next-Jules` field.
+
+**Guidelines for Extensions:**
+
+*   **Prefixing/Tagging:** Extensions should use clear, unique prefixes or tags to identify their purpose and avoid clashes.
+    *   Example: `[ADDON_NAME_FEATURE_STATUS]: Details...`
+    *   Example: `[PROGRESS_TRACKING_PERCENT_COMPLETE]: 70%`
+*   **Documentation:** Any "Prompt Add-on" or process that introduces specific structured extensions to be used within `Notes-To-Next-Jules` **must** document these extensions as part of the add-on's definition or its usage guide.
+*   **Clarity:** Extensions should be human-readable and provide clear value.
+*   **Separation:** Use newlines or clear separators (like Markdown headings) within `Notes-To-Next-Jules` to distinguish different pieces of extended information from general notes.
+
+**Example of `Notes-To-Next-Jules` with Extensions (Illustrative - actual tags depend on add-ons used):**
+\`\`\`
+Notes-To-Next-Jules:
+This commit implements the core authentication logic.
+
+[PLANNING_MPS_PROGRESS]
+- Current step in \`_dev_plan.md\`: Step 4.2: Implement token generation
+- Percentage complete (approximate for this Sub-Task-ID): 80%
+- Key accomplishments in THIS commit:
+  - JWT token generation implemented.
+
+[TASK_RESUMPTION_ADDON_STATUS]
+- Resumption_Prompt_Location: project_alpha/outputs/p1_t1_auth_service_resumption_prompt.txt (Updated)
+
+[BLOCKERS]
+- Waiting for clarification on session timeout.
+
+General Notes:
+The token expiration is currently set to 1 hour.
+\`\`\`
+
+## 4. Responsibilities
+
+*   **AI Instances:** Must adhere to the Base IEP core fields in all commits. If guided by a Prompt Add-on that defines extensions, the AI must populate those extensions correctly within `Notes-To-Next-Jules`.
+*   **Prompt Add-on Designers:** Must clearly define any IEP extensions their add-on introduces and how they fit within the `Notes-To-Next-Jules` field. They should not redefine Base IEP core fields.
+*   **Users/Reviewers:** Can rely on the Base IEP fields for consistent top-level information and then parse `Notes-To-Next-Jules` for more detailed, structured information provided by various add-ons or task-specific reporting.
+
+This Base IEP, with its clear extensibility mechanism, provides a flexible yet standardized foundation for communication across diverse AI-driven tasks and workflows.

--- a/mps_01/content_for_user_task_resumption_addon.txt
+++ b/mps_01/content_for_user_task_resumption_addon.txt
@@ -1,0 +1,78 @@
+[[START OF 'TASK_RESUMPTION_ADDON' v0.1: Instructions for AI Task Management]]
+
+**Purpose:** This add-on instructs the AI (Jules) to generate a detailed "Resumption Prompt" for the current task it is working on. This allows the current task to be paused and resumed efficiently by another AI instance (or the same AI at a later time) with minimal context loss.
+
+**Instructions for AI (Jules) executing the main task this add-on is appended to:**
+
+1.  **Identify Core Task Details:**
+    *   Review your original prompt for this task (the prompt this add-on is attached to). Identify and summarize:
+        *   The overall goal of this task.
+        *   The specific deliverables requested by the original task prompt.
+    *   Review your `_dev_plan.md` for this task. Note the last completed step and the next planned step(s).
+
+2.  **Summarize Work Completed:**
+    *   Consult your commit history for this task (as per the Base IEP, typically found at `[Actual Path to Prompts Folder]/Information_Exchange_Protocol.md, it is in the repo`).
+    *   List the key actions you have taken and the files you have created or modified for this task. Reference specific commit IDs where appropriate.
+
+3.  **Determine Output Location for Resumption Prompt:**
+    *   The Resumption Prompt file you will create must be saved in the folder specified by the Planning AI as the 'Submodule Plan Destination' (this is where your `_dev_plan.md` and `_next_steps.md` for this task should also reside).
+    *   The filename for the Resumption Prompt must be: `<ExactOriginalTaskPromptFilenameBase>_resumption_prompt.txt`. (e.g., if your original task prompt filename was `p1_t1_some_task.txt`, this file will be `p1_t1_some_task_resumption_prompt.txt`).
+
+4.  **Generate the Resumption Prompt Content:**
+    Create the content for your `<ExactOriginalTaskPromptFilenameBase>_resumption_prompt.txt` file with the following structure:
+
+    \`\`\`text
+    # Resumption Prompt for Task: [Original Task Name/Objective from your main task prompt]
+
+    ## Original Task Goal:
+    [Your summary of the overall goal from your main task prompt]
+
+    ## Original Task Deliverables:
+    [Your list of specific deliverables from your main task prompt]
+
+    ## Current Task State (as of [Current Timestamp]):
+
+    ### Last Completed Step (from your `_dev_plan.md`):
+    [Quote the last completed step from your `_dev_plan.md`]
+
+    ### Next Planned Step(s) (from your `_dev_plan.md`):
+    [Quote the next planned step or steps from your `_dev_plan.md`]
+
+    ### Summary of Work Done So Far (for this task):
+    [Your bulleted list of key actions and files created/modified, with commit references if available. e.g.,
+    - Created initial project structure (Commit: XXXXXX)
+    - Implemented function Y in file Z.py (Commit: YYYYYY)
+    - Encountered issue: [brief description of issue if any is blocking your next step]
+    ]
+
+    ## Files Created/Modified in this Session (relative to project root, primarily within `[Actual User-Specified Task Output Base Path]/<YourPhaseTaskName>/`):
+    [Your list of file paths created or modified during your work session for this task. Ensure paths are clear and relative to the project root.]
+
+    ## Next Steps for Resuming AI:
+    1.  Review the above context thoroughly.
+    2.  Focus on completing: "[Next Planned Step(s) from your `_dev_plan.md`]"
+    3.  Ensure all original task deliverables (from your main task prompt) are met.
+    4.  Continue to update your `_dev_plan.md` and follow the Base IEP (from `[Actual Path to Prompts Folder]/Information_Exchange_Protocol.md, it is in the repo`) for commits.
+    5.  If any blocking issues were noted above, address them first.
+
+    ## Original Full Prompt for this Task (for reference):
+    [[[
+    [You must paste the ENTIRE original prompt content for THIS TASK here. Ensure it's clearly demarcated to avoid confusion with this resumption prompt's own instructions.]
+    ]]]
+    \`\`\`
+
+5.  **Save the Resumption Prompt:**
+    *   Write the content generated in Step 4 to your `<ExactOriginalTaskPromptFilenameBase>_resumption_prompt.txt` file at the location determined in Step 3.
+
+6.  **Update Your Commit Message (Base IEP Extension):**
+    *   When you commit the creation or any update of this `_resumption_prompt.txt`, you **must** extend your commit message as per the Base IEP.
+    *   In the `Notes-To-Next-Jules:` field of your commit message for *this task*, add the following structured tag:
+        `[TASK_RESUMPTION_PROMPT_STATUS]: Updated_At='[Actual Path to Submodule Plan Destination]/<ExactOriginalTaskPromptFilenameBase>_resumption_prompt.txt'`
+        (Ensure you use the correct, full path as resolved from the Planning AI's instructions).
+
+7.  **Initial Creation Timing:**
+    *   You should create the *initial version* of this resumption prompt *before* you begin the primary execution steps of your main task, typically after you have created your initial `_dev_plan.md`. Update it after each significant step or commit.
+
+These instructions are critical for enabling efficient, stateful task handoff. Adhere to them precisely.
+
+[[END OF 'TASK_RESUMPTION_ADDON' v0.1]]

--- a/mps_01/example_structure_for_user_spawn_prompt.md
+++ b/mps_01/example_structure_for_user_spawn_prompt.md
@@ -1,0 +1,69 @@
+# Example Structure for User's Main Spawn Prompt File
+# (e.g., what the user would place in `/prompts/p_gritos_dev_plan_spawn.md` in the target repo)
+
+This document illustrates the recommended structure for the main spawn prompt file that you, the user, will create in the target repository (e.g., in its `/prompts/` directory) and then instruct a "Planning AI" (e.g., a new Jules instance) to read and process.
+
+The spawn prompt should be assembled in the following order:
+
+## 1. User Path Configuration Block
+
+This block tells the Planning AI where to place *its generated outputs* (like the detailed task prompts for your project, the project's `00_task_launch_plan.md`, etc.). Paths should be relative to the repository root where the Planning AI operates. Using `Main Iteration Folder: .` means outputs like `plan/` and `prompts/` folders will be created directly at the repository root.
+
+\`\`\`text
+[[USER PATH CONFIGURATION]]
+Main Iteration Folder: .
+Submodule Plan Destination: plan
+Prompts Folder: prompts
+Inter-AI Communication Folder: prompts/ipc
+User-Specified Task Output Base Path: dev/src/kernel
+[[END USER PATH CONFIGURATION]]
+\`\`\`
+*(Adjust the paths above, especially `User-Specified Task Output Base Path`, according to your specific project's needs and target directory structure.)*
+
+## 2. Your Specific Project Request
+
+This is the main description of what you want the Planning AI to plan. For our "gritos" test case, this would be the "gritos Dev Plan (a003)" text.
+
+\`\`\`text
+gritos Dev Plan (a003) - With gritos_product_specification.md and gritos_product_requirements_full.md as the primary source of information, develop a highly detailed development plan for this called gritos_dev_plan.md (the Plan).
+
+Suggested Steps
+
+Review documents in the concept/research folder of the repository as an input Review the documents in the docs folder as guidance
+You may review other documents in the plan folder but they should only be used to enhance or improve a task, activity, or end product.
+Perform deep research on modern OS architectures and specifically the OSes listed in the OS Kernal Comparison document. Include codebases referenced in the input documents in your research.
+The /concept/inputs folder contains an exemplar development plan "grit_dev_plan.md" (and its subplans). Use it as the standard for the expected style, level of detail, and implementation guidance expected in the gritos_dev_plan.md document.
+
+Present a plan to create gritos_dev_plan.md and highly detailed supporting subplans to the same level of detail and quality as the files in concept/inputs. Try to develop the plan such that it can be broken down into 2-5 phases with multiple tasks in each phase. The goal is to divide the tasks within each Phase such that they can be developed in parallel by multiple Jules instances.
+\`\`\`
+*(Replace the above gritos text with your actual high-level project request.)*
+
+## 3. The Master Prompt Segment (MPS) Text
+
+Append the full, unmodified content of the `updated_Master_Prompt_Segment.txt` (which this Jules instance will provide to you, from `/mps_01/updated_Master_Prompt_Segment.txt` in its development repo). This MPS text contains the detailed instructions for the Planning AI on *how* to process your request, generate phased plans, create task prompts, handle IEPs by reading your provided Base IEP from `/prompts/ipc/Base_IEP.txt`, incorporate add-ons by reading your provided add-on files from `/prompts/add_ons/`, etc.
+
+**Important:** The version of the MPS text you append here should be the one that instructs the Planning AI to *read* the Base IEP and any add-ons from predefined paths within *your target repository's `/prompts/` structure* (e.g., from `/prompts/ipc/Base_IEP.txt` and `/prompts/add_ons/your_addon.txt`).
+
+\`\`\`text
+--------------------------------------------------------------------------------------------------------------
+[[START OF MASTER PROMPT SEGMENT: AI Project Planning & Task Generation Instructions]]
+
+ATTENTION PLANNING AI: Your primary function is to interpret the user's project request (provided immediately preceding this segment) and generate a comprehensive, phased execution plan...
+
+(... Rest of the entire updated Master Prompt Segment text, as defined in `/mps_01/updated_Master_Prompt_Segment.txt` ...)
+
+[[END OF MASTER PROMPT SEGMENT]]
+\`\`\`
+
+---
+
+**Summary of Setup for Planning AI (by User):**
+
+Before invoking the Planning AI with a prompt like `"/prompts/p_your_project_spawn_prompt.md is the prompt, it is in the repo"`:
+
+1.  **Create your spawn prompt file** (e.g., `/prompts/p_your_project_spawn_prompt.md`) in the target repo, structured as shown above (User Path Config + Your Project Request + Updated MPS Text).
+2.  **Place the Base IEP content** (provided by this Jules instance as `/mps_01/content_for_user_Base_IEP.txt`) into a file at the path referenced by the updated MPS (e.g., `/prompts/ipc/Base_IEP.txt` in the target repo).
+3.  **Place any referenced Add-on texts** (e.g., content from `/mps_01/content_for_user_task_resumption_addon.txt`) into files at paths referenced by the updated MPS (e.g., `/prompts/add_ons/task_resumption_addon.txt` in the target repo).
+4.  **Ensure all other input documents** required by "Your Specific Project Request" (e.g., product specifications, research docs for gritos) are present in the target repo at the locations your project request section refers to.
+
+The Planning AI will then use your spawn prompt to understand its tasks, read the Base IEP and add-ons from the locations you set up, and generate its outputs (the target project's detailed plan, task prompts, etc.) into the directories specified in your `[[USER PATH CONFIGURATION]]` block.

--- a/mps_01/updated_Master_Prompt_Segment.txt
+++ b/mps_01/updated_Master_Prompt_Segment.txt
@@ -1,0 +1,144 @@
+[[START OF MASTER PROMPT SEGMENT: AI Project Planning & Task Generation Instructions]]
+
+ATTENTION PLANNING AI: Your primary function is to interpret the user's project request (provided immediately preceding this segment) and generate a comprehensive, phased execution plan. This involves creating detailed task prompts for subsequent AI instances ("Task AIs") and all necessary supporting documentation. Adhere strictly to the following instructions and output requirements.
+
+**I. USER-SPECIFIED PATHS & DEFAULTS:**
+The user may provide paths for:
+    A. Destination for submodule development plans (`_dev_plan.md`, `_next_steps.md`).
+    B. Folder for generated task prompts and launch plans (defaults to `prompts/` within the main iteration folder).
+    C. Folder for inter-AI communication/documentation (defaults to `prompts/ipc/` within the chosen prompts folder).
+    D. The main iteration folder (defaults to `/mps_XX/` at the repository root, where XX is the current iteration number, e.g., `01`).
+    E. A User-Specified Task Output Base Path (where Task AIs should place their primary deliverables like code).
+
+You **must** parse the `[[USER PATH CONFIGURATION]]` block at the beginning of this overall prompt. Use the paths specified there.
+*   If `Main Iteration Folder` is specified as `.` (dot), this signifies the repository root. All other relative paths specified in the configuration (like for 'Prompts Folder' or 'Submodule Plan Destination') are then considered directly under this repository root (e.g., `prompts/`, `plan/`).
+*   If `Main Iteration Folder` specifies a directory name (e.g., `my_project_outputs`), then other paths are typically nested within it (e.g., `my_project_outputs/prompts/`).
+*   If any path (other than `Main Iteration Folder`) is missing from the `[[USER PATH CONFIGURATION]]` block, you may use a logical default *relative to the determined Main Iteration Folder*, but state this assumption clearly in your `00_task_launch_plan.md`.
+All paths you generate in prompts and plans must be constructed clearly, typically relative to the repository root, and reflect these user-specified locations. When resolving path placeholders like `[Actual Path to Prompts Folder]`, if `Main Iteration Folder` was specified as `.` and `Prompts Folder` was `prompts`, then `[Actual Path to Prompts Folder]` resolves to `prompts`.
+
+You will also need to read certain definition files provided by the user (e.g., for the Base IEP and any specified Add-ons). These files are expected to be in predefined paths relative to the repository root where you are invoked (e.g., `/prompts/ipc/Base_IEP.txt`, `/prompts/add_ons/some_addon.txt`). The specific paths for these input definition files will be referenced directly in the relevant instruction sections below.
+
+**II. CORE PLANNING & TASK DEFINITION DIRECTIVES:**
+1.  **Understand User's Project:** Thoroughly analyze the user's project description, including any referenced input documents (specifications, research, requirements) and exemplar plans for style and detail. Perform research if indicated. The primary deliverable you will be creating based on the user's request is often a main development plan document (e.g., `gritos_dev_plan.md`); your subsequent task prompts will break this main plan into executable pieces.
+2.  **Phased Structure:** Decompose the project into 2-5 logical phases. Tasks within a phase should be executable in parallel; phases themselves are sequential.
+3.  **Task Granularity & Parallelism:** Define tasks within each phase to be as granular as possible while remaining meaningful. Design these tasks for maximum parallel execution by different Task AIs.
+4.  **Merge Conflict Mitigation Strategy (HIGHEST PRIORITY):**
+    *   Your **highest priority** during task decomposition is the elimination or severe mitigation of potential merge conflicts.
+    *   Actively identify any tasks that might write to the same file(s) or where one task might read a file that a concurrent task in the same phase modifies.
+    *   If such a potential conflict is identified:
+        *   First, attempt to redesign the tasks to operate on entirely separate files or distinct, non-overlapping parts of shared files. Task AIs should primarily create *new* files in their designated output directories (see `User-Specified Task Output Base Path`).
+        *   If redesign is not feasible to completely avoid the conflict, you **must** serialize these tasks. This means placing them in different phases, or if they must remain within the same conceptual phase due to logical grouping, ensure your generated `00_task_launch_plan.md` clearly indicates a specific sequential order for these conflicting tasks *within* that phase, and the task prompts reflect this dependency.
+        *   Task prompts for serialized tasks must clearly state their dependencies on the completion of preceding tasks.
+    *   If a task *must* modify existing shared code (as per the `User-Specified Task Output Base Path`), the task prompt you generate for that task must be *extremely specific* about the exact functions,
+classes, or sections of code to be modified, the nature of the changes, and any assumptions about the state of that shared code. Also, instruct the Task AI to be extra vigilant in using the `Owned-Files-Modules` field in the Information Exchange Protocol (IEP) for such shared resources.
+5.  **File Naming Conventions:**
+    *   Main Development Plan (if you are creating/drafting its content): As specified by user (e.g., `gritos_dev_plan.md`), place in the "Submodule Plan Destination" path.
+    *   Task Prompts: `p<Phase#_t<Task#_<brief_description_lowercase_underscores>.txt` (e.g., `p1_t1_database_schema.txt`).
+    *   Task Launch Plan: `00_task_launch_plan.md`.
+    *   Submodule Dev Plans (created by Task AIs): `<prompt_filename_base>_dev_plan.md` (e.g., `p1_t1_database_schema_dev_plan.md`).
+    *   Next Steps Docs (created by Task AIs): `<prompt_filename_base>_next_steps.md`.
+
+**III. OUTPUT GENERATION REQUIREMENTS:**
+
+All file paths below are relative to the "Main Iteration Folder" identified from the `[[USER PATH CONFIGURATION]]` block (which could be the repository root if `.` was specified).
+
+**A. Main Development Plan Document (e.g., `gritos_dev_plan.md`):**
+    *   Based on the user's request, you will develop the content for this plan.
+    *   **Location:** Place this file in the "Submodule Plan Destination" path.
+        *   Example 1: If 'Main Iteration Folder' is `gritos_mps_test_01` and 'Submodule Plan Destination' is `gritos_mps_test_01/plan`, then the file is `gritos_mps_test_01/plan/gritos_dev_plan.md`.
+        *   Example 2: If 'Main Iteration Folder' is `.` and 'Submodule Plan Destination' is `plan`, then the file is `plan/gritos_dev_plan.md` (relative to the repository root).
+
+**B. Task Prompt Files (`.txt`):**
+    *   **Location:** Create in the designated "Prompts Folder".
+        *   This path is interpreted relative to the 'Main Iteration Folder'. For example, if 'Main Iteration Folder' is `gritos_mps_test_01` and 'Prompts Folder' is `gritos_mps_test_01/prompts`, files go into `gritos_mps_test_01/prompts/`. If 'Main Iteration Folder' is `.` and 'Prompts Folder' is `prompts`, then files go into `prompts/` at the repository root.
+    *   **For Each Task Defined in your Main Development Plan, Generate a Prompt File Containing:**
+        1.  **Task Overview:** Purpose of this specific task, its contribution to the current phase and overall project. Reference the relevant section of the Main Development Plan document you created.
+        2.  **Sub-Development Plan Directive:**
+            *   "You must first create a detailed sub-development plan for this task. Save it as `<PhaseTaskName>_dev_plan.md` in the user-specified submodule plan destination folder: `[Actual User-Specified Path for Submodule Plans from [[USER PATH CONFIGURATION]]]`. This plan must list your detailed steps. Mark your progress in this file (e.g., using markdown checkboxes: `[ ] Step 1`, `[x] Step 2`)."
+        3.  **Detailed Task Execution Instructions:** Clear, actionable steps to complete the task, referencing any necessary input documents (e.g., sections from the Main Development Plan, product specifications).
+        4.  **Output Management:**
+            *   "Place all new files, code, or artifacts created *specifically for this task* and not intended as direct modifications to existing shared project code into a dedicated task-specific subdirectory within the `User-Specified Task Output Base Path`. For this task, your primary output subdirectory should be `[Actual User-Specified Task Output Base Path]/<PhaseTaskName>/`. If this task involves modifying existing shared project code directly within `[Actual User-Specified Task Output Base Path]`, refer to the specific instructions above regarding those modifications and be meticulous with IEP commit messages and the `Owned-Files-Modules` field." (Ensure `<PhaseTaskName>` is specific to the task).
+        5.  **Information Exchange Protocol (IEP) Adherence:**
+            *   "You **must** strictly adhere to the `Information_Exchange_Protocol.md` (located in `[Actual Path to Prompts Folder]/Information_Exchange_Protocol.md, it is in the repo`) for all your commit messages. Pay close attention to `Status`, `Owned-Files-Modules`, `[BLOCKERS / ISSUES]`, and `[PROGRESS]` sections."
+        6.  **"Next Steps & Improvements" Document Directive:**
+            *   "After completing your primary task, create a document named `<PhaseTaskName>_next_steps.md` in the same location as your `_dev_plan.md` (`[Actual User-Specified Path for Submodule Plans]`). This document must include:
+                *   Potential next steps, enhancements, or optimizations for the content/code you developed.
+                *   A dedicated section titled 'AI-Automated PR Suggestions': Your thoughts on how a Pull Request for your work could be best formulated for AI-assisted creation/review.
+                *   A section titled 'Other Recommendations': Any general recommendations for improving the overall project or development process."
+        7.  **Inter-AI Communication Directive:**
+            *   "For persistent communication, detailed logs, or shared artifacts relevant to other AI tasks that don't fit commit messages, use the designated inter-AI communication folder: `[Actual Path to Prompts Folder]/ipc/`. Document any such usage in your commit messages."
+        8.  **Retry Logic (Verbatim Text):**
+            *   "```If you are starting this task and a previous AI instance may have already worked on it and crashed, your first step is to thoroughly investigate and determine what that instance completed. Check version control (git log), the file system (especially in `[Actual User-Specified Path for Submodule Plans]/<PhaseTaskName>_dev_plan.md` and your task output directory `[Actual User-Specified Task Output Base Path]/<PhaseTaskName>/`), and any logs in `[Actual Path to Prompts Folder]/ipc/`. Document your findings in your `_dev_plan.md`. Then, proceed to complete the task fully from where the previous instance left off. Do not repeat successfully completed work.```" (Ensure `<PhaseTaskName>` is correctly substituted).
+        9.  **Path Referencing:** When providing file paths to the Task AI, append ", it is in the repo." to aid discovery.
+
+**C. Supporting Documentation (in the designated "Prompts Folder" for the target project):**
+
+1.  **`Information_Exchange_Protocol.md`:**
+    *   Read the content from the user-provided Base IEP file located at `/prompts/ipc/Base_IEP.txt` (this path is relative to the repository root where you, the Planning AI, are operating; it is in the repo).
+    *   You **must** create a file named `Information_Exchange_Protocol.md` in the 'Prompts Folder' you are generating for the target project (e.g., `[Actual Path to Target Project's Prompts Folder]/Information_Exchange_Protocol.md`).
+    *   Write the exact, unmodified content read from `/prompts/ipc/Base_IEP.txt` into this new file. This ensures the target project uses the standard Base IEP provided by the user.
+
+2.  **`00_task_launch_plan.md`:**
+    *   Create this file. Its content **must be based on the following template.** You **must** dynamically replace placeholders like `[Project Name Placeholder]`, `[Iteration Placeholder XX]`, `[Actual Main Iteration Folder Path]`, `[Actual Path to Prompts Folder]`, `[Actual User-Specified Path for Submodule Plans]`, and `[Actual User-Specified Task Output Base Path]` with the actual values derived from the user's request and the `[[USER PATH CONFIGURATION]]` block. You must also dynamically generate the task listing.
+    *   **CRITICAL FOR LAUNCH COMMANDS:** Ensure the launch paths in `00_task_launch_plan.md` are always correctly formed relative to the repository root. For example, if 'Main Iteration Folder' is `.` and 'Prompts Folder' is `prompts`, a launch path will be `prompts/p1_t1_task.txt is the prompt, it is in the repo.`. If 'Main Iteration Folder' is `iter_outputs` and 'Prompts Folder' is `iter_outputs/prompts`, the path will be `iter_outputs/prompts/p1_t1_task.txt is the prompt, it is in the repo.`.
+        ```markdown
+        # Task Launch Plan for [Project Name Placeholder] - Iteration [Iteration Placeholder XX]
+
+        ## 1. Overview
+        Welcome to the Task Launch Plan for **[Project Name Placeholder]**, Iteration **[Iteration Placeholder XX]**! This document provides all the necessary information to launch and manage the development tasks generated for this project.
+        The project has been decomposed into several phases. Each phase contains one or more tasks designed by the Planning AI. Tasks within the same phase can often be executed in parallel by different AI instances (e.g., Jules instances) *unless a specific order is indicated below due to dependencies*.
+
+        **Key Files & Folders (relative to this iteration's root folder, e.g., `[Actual Main Iteration Folder Path]/`):**
+        *   `[Actual Path to Prompts Folder]/`: Contains this launch plan, all individual task prompt files (`.txt`), and the Information Exchange Protocol.
+        *   `[Actual Path to Prompts Folder]/ipc/`: A dedicated space for inter-AI instance communication.
+        *   `[Actual User-Specified Path for Submodule Plans]`: The location Task AIs will store their `_dev_plan.md` and `_next_steps.md` files.
+        *   `[Actual User-Specified Task Output Base Path]`: The base directory where Task AIs will place their primary deliverables (e.g., code). Task-specific subdirectories will be created within this path.
+
+        ## 2. Execution Workflow
+        1.  **Review Phases:** Understand the sequential nature of phases. All tasks in a preceding phase should be completed and verified before starting tasks in a subsequent phase.
+        2.  **Parallel Task Execution:** Tasks listed *within the same phase* below can be assigned to different AI instances simultaneously, *unless a specific execution order is noted for particular tasks due to dependencies (e.g., to avoid merge conflicts)*.
+        3.  **Provide Prompts to AI Instances:** For each task, copy the "Initial Launch" command and provide it to an AI instance.
+        4.  **Monitor Progress:**
+            *   Regularly check commit messages (see `[Actual Path to Prompts Folder]/Information_Exchange_Protocol.md, it is in the repo`).
+            *   Review `_dev_plan.md` files in `[Actual User-Specified Path for Submodule Plans]`.
+            *   Check `[Actual Path to Prompts Folder]/ipc/` for inter-AI communications.
+        5.  **Handle Crashes:** If an AI instance crashes, use the "Retry if Crashed" command for that task.
+
+        ## 3. Launching Tasks
+        Below are the tasks, organized by phase.
+        ---
+        [[YOU MUST DYNAMICALLY GENERATE THE TASK LISTING BELOW BASED ON THE PROMPT FILES YOU CREATED]]
+        [[FOR EACH PHASE:]]
+        ### **Phase <PhaseNumber> Tasks**
+        [[IF ANY TASKS IN THIS PHASE ARE SERIALIZED, ADD A NOTE HERE EXPLAINING THE SEQUENCE]]
+
+        [[FOR EACH TASK IN THE PHASE:]]
+        #### **Task: `<Full Prompt Filename e.g., p1_t1_setup_core_framework.txt>`**
+        *   **Description:** <A brief, 1-2 sentence user-friendly description of this task's objective, derived from your Main Development Plan.>
+        *   **Initial Launch:**
+            \`\`\`
+            [Path to Prompt File relative to Repo Root] is the prompt, it is in the repo.
+            \`\`\`
+        *   **Retry if Crashed:**
+            \`\`\`
+            [Path to Prompt File relative to Repo Root] is the prompt, it is in the repo, but a previous Jules instance crashed. Your task is to determine what the previous instance was able to complete before crashing, and to continue and complete the task.
+            \`\`\`
+        ---
+        [[END OF DYNAMICALLY GENERATED TASK LISTING]]
+
+        ## 4. Iteration Completion
+        Once all tasks in all phases are reported as `Tested` or `Completed` satisfactorily, this project iteration can be considered complete. Review `_next_steps.md` documents in `[Actual User-Specified Path for Submodule Plans]`.
+        Good luck with project **[Project Name Placeholder]**!
+        ```
+        (End of 00_task_launch_plan.md template)
+
+**IV. FINAL INSTRUCTION TO PLANNING AI:**
+Your own final commit message for completing *this planning and generation task* must also adhere to the `Information_Exchange_Protocol.md` (the one you copied from `/prompts/ipc/Base_IEP.txt`). Use a relevant Task-ID like "INITIAL_PROJECT_PLANNING_ITER_XX" (replace XX with the iteration number from `Main Iteration Folder` if it's not '.').
+
+**V. TASK RESUMPTION ADD-ON INCORPORATION (MANDATORY, if specified by user setup):**
+The user may provide a "Task Resumption Add-on" to enhance task robustness.
+1.  **Check for Add-on:** You should expect to find the text for this add-on in a file at `/prompts/add_ons/task_resumption_addon.txt` (this path is relative to the repository root where you, the Planning AI, are operating; it is in the repo).
+2.  **If Present, Incorporate:** If this file exists, for every task prompt you generate as per Section III.B above, you **must append** the complete and unmodified content of this "Task Resumption Add-on".
+3.  **Resolve Placeholders:** You are responsible for reading this file and including its content in each generated task prompt. Critically, ensure all path placeholders within the add-on text itself (e.g., `[Actual Path to Prompts Folder]`, `[Actual User-Specified Path for Submodule Plans]`, `[Actual User-Specified Task Output Base Path]`, `<ExactOriginalTaskPromptFilenameBase>`) are correctly resolved by you with the values from the `[[USER PATH CONFIGURATION]]` block (or your defaults) when you embed the add-on into the final task prompts for the target project.
+
+[[END OF MASTER PROMPT SEGMENT]]


### PR DESCRIPTION
…you requested.

Here's a summary of what I did:

I've made changes so that the MPS no longer embeds the full text of the Information Exchange Protocol (IEP) or specific add-ons like the Task Resumption Add-on.

Instead, the updated MPS now guides the "Planning AI" to:
1. Access the Base IEP content from a file path you provide (e.g., `/prompts/ipc/Base_IEP.txt` in the Planning AI's target repo).
2. Access the content of any specified add-ons (e.g., Task Resumption Add-on) from another file path you provide (e.g., `/prompts/add_ons/task_resumption_addon.txt` in the Planning AI's target repo).
3. The Planning AI then uses this accessed content to generate the necessary `Information_Exchange_Protocol.md` for the target project and to append add-on text to task prompts.

The following files have been created or updated:
- `mps_01/content_for_user_Base_IEP.txt`: This file contains the content you should place in your Base IEP file.
- `mps_01/content_for_user_task_resumption_addon.txt`: This file contains the content you should place in your task resumption add-on file.
- `mps_01/updated_Master_Prompt_Segment.txt`: This file contains the new MPS text.
- `mps_01/example_structure_for_user_spawn_prompt.md`: This file provides a guide on how you should structure your main spawn prompt for the Planning AI, incorporating the updated MPS and referencing the externalized IEP/add-on files.

This change makes the MPS itself leaner and gives you more direct control over the IEP and add-on definitions by managing them as separate files in your target project's prompt structure.

I've committed these four new/updated files. This part of the work is now complete. I didn't run into any issues.

This addresses your feedback to make the MPS leaner and have it reference your provided files for IEP and add-ons, rather than embedding their full text.