### PR TITLE
feat: Implement directive-based MPS invocation workflow

### DIFF
--- a/framework_dev_docs/meta/HANDOFF_NOTES.md
+++ b/framework_dev_docs/meta/HANDOFF_NOTES.md
@@ -441,667 +441,40 @@ The plan was revised to implement and document this new search order:
 - Review the `framework_dev_docs/meta/implement_mps_updater.txt` file.
 - When ready, assign the task described in that file to a new Jules instance.
 ---
-
-## MPS Performance Feedback Log
-
-This section logs specific feedback on the performance, clarity, and effectiveness of the Master Prompt Segment (MPS) versions and the artifacts they help generate.
-
----
-**Feedback Entry - 2023-11-02**
-**Source of Feedback:** Initial setup of this feedback log section during MPS feature design.
-**MPS Version Referenced:** Relevant for `prompts/Master_Prompt_Segment.txt` (v0.3.2 and future versions).
-**Context/Scenario:** Establishing the feedback mechanism as per design discussions for feature "Feedback Loop for MPS Refinement".
-**Observation/Issue:** This log is intended to capture issues like:
-    - Ambiguities in any version of `Master_Prompt_Segment.md` that lead to incorrect or suboptimal behavior by a Planning AI.
-    - Problems encountered by Task AIs due to the structure or content of prompts generated based on an MPS version.
-    - User difficulties in understanding or using the MPS, its generated `00_task_launch_plan.md`, or other artifacts.
-    - Success stories where a particular MPS instruction proved very effective.
-**Suggestion for MPS Refinement (if any):** N/A
----
-*(Future entries will be appended below this line)*
----
----
-**Feedback Entry Date:** 2023-10-27
-**Source of Feedback:** User (via direct request to Jules instance for refactoring).
-**MPS Version Referenced:** `prompts/Master_Prompt_Segment.txt` (approx. v0.3.2, prior to modularization) and the new modularized version (post this session's changes).
-**Context/Scenario:** User identified that the `Master_Prompt_Segment.txt` was becoming very long and dense, making it difficult to read, manage, and maintain.
-**Observation/Issue:** The monolithic nature of `Master_Prompt_Segment.txt` was impacting usability and the ease of making targeted changes to core planning instructions without affecting user-configurable sections.
-**Suggestion for MPS Refinement (Implemented):** To improve readability and maintainability, the core planning AI instructions were extracted from `Master_Prompt_Segment.txt` and placed into a new, dedicated file: `prompts/iep/Core_Planning_Instructions.txt`. The `Master_Prompt_Segment.txt` now includes these instructions using an `[[INCLUDE Core_Planning_Instructions.txt FROM /prompts/iep/Core_Planning_Instructions.txt]]` directive. This separation is intended to make both the user-facing configuration parts of the MPS and the core instructional logic easier to manage.
----
----
-**Feedback Entry Date:** 2023-10-27
-**Source of Feedback:** User (via direct request and illustrative example: `[ ] task_spawning_addon.txt` to Jules instance).
-**MPS Version Referenced:** The modularized MPS version (where `Core_Planning_Instructions.txt` was already separate) and the current version implementing optional task spawning via `task_spawning_addon.txt`.
-**Context/Scenario:** User desired to further enhance the framework's modularity by making the entire project planning and task generation process an optional component, selectable by the user, rather than an inherent, non-optional function of the MPS.
-**Observation/Issue:** While `Core_Planning_Instructions.txt` was already separated, it still implicitly mandated the task spawning workflow. The framework lacked the flexibility to be used for other purposes without invoking this primary planning behavior.
-**Suggestion for MPS Refinement (Implemented):** The user's suggestion to make task spawning an optional add-on was implemented.
-    - The core logic for project planning, TLP generation, and task prompt creation was moved from `prompts/iep/Core_Planning_Instructions.txt` to a new file: `prompts/add_ons/task_spawning_addon.txt`.
-    - `prompts/iep/Core_Planning_Instructions.txt` was updated to include conditional logic. It now checks if `task_spawning_addon.txt` is selected by the user in `[[USER_ADDON_SELECTION]]` (within `Master_Prompt_Segment.txt`).
-    - If selected, the `task_spawning_addon.txt` is executed.
-    - If not selected, the AI is instructed to acknowledge this, skip default plan generation, and process any other selected add-ons.
-    - This change makes the MPS framework significantly more flexible, allowing users to engage the Planning AI for potentially different primary functions by selecting different combinations of add-ons, or by using it with only utility add-ons.
----
----
-**Feedback Entry Date:** 2023-10-27
-**Source of Feedback:** User (clarifying questions and specific directive regarding `task_spawning_addon.txt` inheritance and add-on ordering).
-**MPS Version Referenced:** The MPS version with optional task spawning via `task_spawning_addon.txt`.
-**Context/Scenario:** User inquired about how multiple add-ons interact, particularly how `task_spawning_addon.txt` would affect other add-ons, and then specifically requested that `task_spawning_addon.txt` should not be inherited by the Task AIs it generates. User also sought clarity on the importance of add-on ordering in the selection block.
-**Observation/Issue:**
-    1. The previous add-on processing logic could have resulted in `task_spawning_addon.txt` (intended for the Planning AI) being appended to Task AI prompts, leading to overly verbose prompts and potential for unintended behavior.
-    2. The impact of add-on order in `[[USER_ADDON_SELECTION]]` on the final content of Task AI prompts was not explicitly documented, potentially leading to user confusion.
-**Suggestion for MPS Refinement (Implemented):**
-    - **Non-inheritance of `task_spawning_addon.txt`**: Modified `prompts/iep/Core_Planning_Instructions.txt` (Section I.B) to create a filtered list (`Inheritable_Addons_Content_Ordered_List`) of add-on contents for Task AI prompt inheritance, which explicitly excludes the content of `task_spawning_addon.txt`. This ensures the Planning AI uses `task_spawning_addon.txt` for its process, but Task AIs receive cleaner, more focused prompts.
-    - **Clarified Add-on Ordering**: Updated `prompts/Master_Prompt_Segment.txt` (comments in `[[USER_ADDON_SELECTION]]`) and `framework_dev_docs/guides/MPS_Usage_Guide.md` to explain that the order of inheritable add-ons is preserved when `task_spawning_addon.txt` appends them to task prompts. Also recommended listing `task_spawning_addon.txt` last for visual clarity if used.
-    - These refinements improve the safety and predictability of add-on interactions and provide users with better control and understanding of how their selections affect Task AI prompts.
----
----
-**Feedback Entry Date:** 2023-10-27
-**Source of Feedback:** User (initial idea for process automation, then specific refinements for primary input and reference depth for product specs).
-**MPS Version Referenced:** Current version with extensible primary add-on logic.
-**Context/Scenario:** User expressed a need to use the MPS framework for more than just task spawning, specifically for a structured process to generate product specification documents from various inputs. Later refinements included requests for more control over the research phase of this process.
-**Observation/Issue:** The initial MPS framework was primarily geared towards task spawning. A structured approach was needed to define and execute other complex, multi-step AI-driven processes. For the product specs process,
-        *   Added `PRODUCT_SPECS_PRIMARY_INPUT_FILE`: An optional path to a specific document. The AI is instructed to focus its research by analyzing at least every numbered heading in this document. If not provided, the AI selects the most comprehensive input document for this role.
-        *   Added `PRODUCT_SPECS_REF_DEPTH`: An optional integer (0-2, default 1) to control how many levels deep the AI will follow internal references within the provided document set.
-    These enhancements make the product specification generation process more guided and configurable.
----
----
-**Feedback Entry Date:** 2023-10-27
-**Source of Feedback:** Jules (proactive refinement during development of `build_product_specs_process.txt`).
-**MPS Version Referenced:** Current version with extensible primary add-on logic.
-**Context/Scenario:** The introduction of `build_product_specs_process.txt` as a new "primary directive" add-on (similar in role to `task_spawning_addon.txt` but with a different function) highlighted the need to generalize how the core framework selects and manages such add-ons.
-**Observation/Issue:** The existing logic in `prompts/iep/Core_Planning_Instructions.txt` was somewhat hardcoded around `task_spawning_addon.txt` for determining the main execution path and for non-inheritance of add-on content into sub-prompts. This would not scale well if many different primary add-ons were developed.
-**Suggestion for MPS Refinement (Implemented):**
-    - Modified `prompts/iep/Core_Planning_Instructions.txt` (Section I.B and II) to:
-        - Define a list of `Known_Primary_Directive_Addons`.
-        - Dynamically identify an `Active_Primary_Addon_Filename` by checking the user's selection against this known list, prioritizing the first one selected by the user if multiple are chosen. A warning is logged if multiple primary add-ons are selected.
-        - Ensure that the `Inheritable_Addons_Content_Ordered_List` (used for appending to sub-prompts) correctly excludes the content of the currently `Active_Primary_Addon_Filename`, not just `task_spawning_addon.txt`.
-    - This makes the core framework more robust and extensible, allowing new primary add-ons to be integrated more easily without requiring significant changes to the core conditional logic each time. It also handles user selection of multiple primary add-ons more gracefully.
----
----
-**Feedback Entry Date:** 2023-10-27
-**Source of Feedback:** User (specific feedback on research methodology, codebase interaction rules like "level 0 only for codebases," and codebase review preferences for the `build_product_specs_process.txt` add-on).
-**MPS Version Referenced:** Current version with `build_product_specs_process.txt` add-on.
-**Context/Scenario:** User provided detailed requirements to refine the initial `build_product_specs_process.txt` add-on to achieve a more structured, in-depth, and controllable research and content generation process, particularly focusing on how the AI should interact with a primary document and linked codebases.
-**Observation/Issue:** The initial version of `build_product_specs_process.txt` had a more general research phase. The user required a more granular, heading-based research approach for the Primary Input Document, specific rules for how the AI should analyze linked codebases (including different levels of review depth/focus), and a strict "level 0 only" rule for code analysis to prevent unintended deep dives into code.
-**Suggestion for MPS Refinement (Implemented):**
-The `prompts/add_ons/build_product_specs_process.txt` was significantly updated to incorporate the "Level 0 Deep Research" methodology as per user requirements:
-    - **New Configurations:** Introduced `PRODUCT_SPECS_CODEBASE_REVIEW_PREFERENCE` and `PRODUCT_SPECS_CODEBASE_FOCUS_AREAS` in `Master_Prompt_Segment.txt` and documented them in `MPS_Usage_Guide.md`.
-    - **Per-Heading Research Cycle:** The add-on's Phase 3 was restructured. It now includes an initial high-level review of the Primary Input Document. Then, for each major heading in that document, it performs a 5-step analysis: Heading Context Analysis, Supporting Docs Analysis, References & Codebase Analysis, Consolidated Research for the heading, and Iterative Content Contribution for that heading.
-    - **Codebase Review Integration:** The "References & Codebase Analysis" step now explicitly uses the `PRODUCT_SPECS_CODEBASE_REVIEW_PREFERENCE` ("complex", "cursory", "focused") and `PRODUCT_SPECS_CODEBASE_FOCUS_AREAS` to guide its interaction with linked code.
-    - **"Level 0 Code Analysis ONLY":** A strict rule was added, instructing the AI not to follow internal code references (like imports or function calls to other files) from any fetched code text. Its analysis is confined to the directly retrieved code content.
-    - **Iterative Content Drafting:** Content for output documents is now drafted iteratively during the per-heading analysis and then assembled and finalized in later phases.
-    This refined process provides a more systematic and controllable approach for the AI when generating product specifications.
----
----
-**Feedback Entry Date:** 2023-10-27
-**Source of Feedback:** User (clarifications and new requirements for iterative deepening for `build_product_specs_process.txt`).
-**MPS Version Referenced:** Current version with `build_product_specs_process.txt` add-on incorporating "Level 0 Deep Research".
-**Context/Scenario:** Expanding the iterative capabilities of `build_product_specs_process.txt` from an initial 0-2 level concept to a more detailed 0-3 level process with specific content goals for each level.
-**Observation/Issue:** The initial iterative deepening plan (0-2 levels) for `build_product_specs_process.txt` needed more specific content goals for each level and an additional level for AI-driven insights to meet user's evolving requirements for content depth and sophistication.
-**Suggestion for MPS Refinement (Implemented):**
-The iterative deepening feature of `build_product_specs_process.txt` was expanded to support 0-3 levels, and associated configurations and documentation were updated:
-    - **Configuration Updates (`Master_Prompt_Segment.txt`):** `PRODUCT_SPECS_ITERATION_DEPTH` comment updated to reflect the 0-3 range and specific goals:
-        - `0`: Outline Generation (headings with single key idea paragraphs).
-        - `1`: Basic Content (Bachelor's level, ~3 paras per D0 heading).
-        - `2`: Expert Elaboration (~1 page per original D0 heading).
-        - `3`: AI Unique Insights (~3 pages per original D0 heading, novel ideas).
-    - **Add-on Logic (`build_product_specs_process.txt`):**
-        - Phase 1 (Initialization) now validates depth (0-3) and `PRODUCT_SPECS_PREVIOUS_ITERATION_OUTPUT_PATH` (required for D1-D3, critical error if missing). Output file suffixes `_D0` to `_D3` are determined.
-        - Phase 2 (Input Processing) is conditional: D0 uses original inputs; D1-D3 use previous iteration's outputs as primary, with original inputs as reference.
-        - Phase 3 (Content Generation) has distinct logic for each depth (0-3), detailing how to build upon previous work (for D1-D3) or generate outlines (D0) according to the specified content goals for each level.
-    - **Documentation (`MPS_Usage_Guide.md`):** Updated to detail the 0-3 levels, their specific purposes, and the user workflow for managing iterative runs and output folders.
-    This provides a more granular, powerful, and well-defined iterative workflow for the `build_product_specs_process.txt` add-on.
----
----
-**Feedback Entry Date:** 2023-10-27
-**Source of Feedback:** User (vision for enhanced component modularity via "folder-per-app" architecture).
-**MPS Version Referenced:** Current version with multiple add-ons and utils.
-**Context/Scenario:** As the number of components (add-ons, utils, and potentially IPC handlers) grows, a flat file structure in their respective directories (`prompts/add_ons/`, `prompts/util/`) becomes less organized and limits the ability for components to have their own supporting files or sub-frameworks.
-**Observation/Issue:** The previous flat-file structure for add-ons and utils was not ideal for scalability or for components that might require multiple associated files (e.g., templates, data snippets, complex sub-instructions).
-**Suggestion for MPS Refinement (Implemented):**
-The framework was refactored to a "folder-per-app" architecture for all components (add-ons, utils, and anticipated IPC handlers):
-    - **Core Logic (`prompts/iep/Core_Planning_Instructions.txt`):** Updated to discover and load components based on a new directory structure.
-        - It now expects component-specific parent paths like `User_Path_Addons_Dir`, `User_Path_Utils_Dir`, `User_Path_IPC_Dir` to be defined in `[[USER PATH CONFIGURATION]]`.
-        - For each component "app" (e.g., `my_addon_app`), it looks for a subdirectory named `my_addon_app` within the relevant parent path.
-        - The primary instruction file for the app must be located at `[parent_path]/my_addon_app/my_addon_app.txt`.
-        - Internal references (e.g., `Known_Primary_Directive_Addon_Apps`, `Active_Primary_Addon_AppName`) now use these app/folder names.
-    - **Component Migration:** All existing add-ons (`task_spawning_addon`, `task_resumption_addon`, `build_product_specs_process`) and utils (`pre_flight_check_user_plan`) were moved into their respective new subdirectories (e.g., `prompts/add_ons/task_spawning_addon/task_spawning_addon.txt`).
-    - **New `prompts/ipc/` directory:** Created with a `.gitkeep` file for future IPC components.
-    - **Documentation Updates:**
-        - `prompts/add_ons/available_addons_manifest.md`: Updated to list add-ons by their app/folder name and describe the new structure.
-        - `framework_dev_docs/guides/MPS_Usage_Guide.md`: Comprehensively updated to explain the "folder-per-app" architecture, how users should set up paths, how components are selected, and how developers should structure new components.
-    This architectural change significantly improves modularity, organization, and the potential for more complex, self-contained components within the MPS framework.
----
----
-**Feedback Entry Date:** 2023-10-27
-**Source of Feedback:** User (desire to simplify MPS, new way to handle app-specific data, AI assistance for missing/default configs, specific format for detecting edits).
-**MPS Version Referenced:** v0.4.0 (Master Prompt Segment and Core Planning Instructions).
-**Context/Scenario:** This feedback entry summarizes a series of user requests and design discussions aimed at a comprehensive overhaul of the MPS framework's configuration system and a significant enhancement of the `build_product_specs_process` add-on's iterative capabilities.
-**Observation/Issue:**
-    1.  The global `[[USER PATH CONFIGURATION]]` in `Master_Prompt_Segment.txt` was becoming unwieldy; app-specific configs were mixed with global ones; parameter precedence and user edit detection were not formalized.
-    2.  A more structured and discoverable way to manage parameters for individual add-on apps was needed, including clear defaults and user override mechanisms.
-    3.  Users needed assistance in setting mandatory parameters, especially those with placeholder defaults.
-**Suggestion for MPS Refinement (Implemented):**
-A comprehensive refactoring of the configuration system was performed:
-    1.  **Fixed Global System Paths:** Core component discovery paths (for add-ons, utils, IEP, IPC) are now hardcoded in `Core_Planning_Instructions.txt`, simplifying user setup.
-    2.  **`[[USER PATH CONFIGURATION]]` Removed from `Master_Prompt_Segment.txt`:** This block was deleted. General output paths (like `Main Iteration Folder`) and other process-specific parameters are now intended to be managed as parameters within the configuration system of the relevant app.
-    3.  **App-Specific Configuration System:**
-        *   **`USER_appName_CONFIG.txt` Standard:** Defined a standard format for these template/storage files within each app's folder. This includes `[[USER_CONFIG_FOR_appName]]` delimiters, and per-parameter metadata (`# Requirement: [Required|Optional] | DefaultType: [Accepted|Placeholder]`), description with default (`# Description: ... Default: ...`), and the value line (`PARAM_NAME: [USER_VALUE_START]value[USER_VALUE_END]`).
-        *   **Main Prompt Overrides:** Users can copy the content of a `USER_appName_CONFIG.txt` into their main spawn prompt to provide run-specific overrides.
-        *   **Parameter Resolution Precedence:** Implemented in app logic (demonstrated in `build_product_specs_process.txt`): Main prompt block > User-edited `USER_appName_CONFIG.txt` > AcceptedDefault in `USER_appName_CONFIG.txt`.
-        *   **AI-Assisted Updates:** If a `Required` parameter with a `PlaceholderDefault` remains unresolved, the app instructs the AI (Jules) to request the value from the user via chat. The AI then updates the on-disk `USER_appName_CONFIG.txt` with the new value and outputs the complete updated config block for the user to transfer to their main spawn prompt.
-    4.  **Documentation:** All changes were reflected in `Master_Prompt_Segment.txt` (now v0.4.0), `Core_Planning_Instructions.txt`, `MPS_Usage_Guide.md`, and relevant add-on files (e.g., `build_product_specs_process/USER_build_product_specs_process_CONFIG.txt` and its primary instruction file).
-    This new system offers improved modularity, clarity in parameter management, and a better user experience through AI-assisted configuration.
----
----
-**Session Summary - 2023-10-27**
-**Instance:** Jules
-**Key Accomplishments This Session (Finalizing Configuration System & Preparing for "Concept Task" Handoff):**
-This session concluded the major refactoring of the MPS framework's configuration system and component architecture. It also prepared for the next phase of work focusing on the "Concept task."
-
-*   **Configuration System Refactoring (Completion & Documentation):**
-    *   **Standard for `USER_appName_CONFIG.txt`:** Formalized the standard for these files, including app-specific delimiters (`[[USER_CONFIG_FOR_appName]]`), and per-parameter metadata (`# Requirement: [Required|Optional] | DefaultType: [Accepted|Placeholder]`), descriptions, defaults, and `[USER_VALUE_START]...[USER_VALUE_END]` markers. An illustrative example (`USER_exampleApp_CONFIG.txt`) was created as part of this standard definition.
-    *   **Applied Standard:** The `build_product_specs_process` add-on's `USER_build_product_specs_process_CONFIG.txt` was updated to fully adhere to this new standard, with all its parameters classified.
-    *   **Refined App Logic (`build_product_specs_process.txt` v0.4):** Its parameter resolution logic in Phase 1 was enhanced to parse the new metadata from `USER_..._CONFIG.txt`. The AI-assisted update mechanism (asking user via chat) now correctly triggers only for "Required" parameters with "PlaceholderDefault" values that haven't been overridden. A final validation step ensures all "Required" parameters have valid values before proceeding, halting with an error if not.
-    *   **Streamlined `Master_Prompt_Segment.txt` (v0.4.0):** The global `[[USER PATH CONFIGURATION]]` block was definitively removed. Instructions in `[[USER_ADDON_SELECTION]]` were updated to guide users on app-specific configurations via `[[USER_CONFIG_FOR_appName]]` blocks in their main spawn prompt.
-    *   **Consolidated `MPS_Usage_Guide.md`:** The guide was thoroughly reviewed and updated to provide a comprehensive and consistent explanation of the new configuration system. This includes: fixed global system paths, the role and format of `USER_appName_CONFIG.txt` files, the user workflow for app configuration (using main prompt blocks or editing `USER_...CONFIG.txt`), the AI's parameter resolution precedence, and how AI-assisted updates work. The "folder-per-app" architecture is also clearly documented.
-
-*   **Next Area of Work (User Directed - For Next Jules Instance):**
-    *   The user has directed focus towards refining an existing "Concept task."
-    *   This will involve analyzing the "Concept task" and splitting it into approximately three sub-tasks.
-    *   A key aspect of this work will be to use the "Concept task" sub-tasks as a practical use case for **exploring and implementing extensions to the 'add-on, util, and process' component concepts** within the MPS framework.
-    *   The next Jules instance is tasked with initiating this by requesting detailed requirements from the user regarding the "Concept task" (current state, materials possibly in `Inputs/concept/inputs`, ideas for sub-tasks) and their initial thoughts on evolving the component model.
-
-**State of Deliverables:**
-The comprehensive refactoring of the MPS configuration system is complete. This includes the "folder-per-app" architecture, fixed system paths for component discovery, and the new app-specific configuration mechanism using `USER_appName_CONFIG.txt` files and `[[USER_CONFIG_FOR_appName]]` blocks, featuring AI-assisted updates. All core prompts and documentation (`Master_Prompt_Segment.txt`, `Core_Planning_Instructions.txt`, `MPS_Usage_Guide.md`, `available_addons_manifest.md`, and relevant add-ons like `build_product_specs_process`) have been updated to reflect these changes. The framework is significantly more modular, user-friendly, and robust in its configuration management. No new code or prompt changes were made in this specific summarization step. The system is ready for handoff to the next Jules instance to begin work on the "Concept task" and component model evolution.
----
----
-**Feedback Entry Date:** 2025-06-02
-**Source of Feedback:** User (new directive for next area of work following completion of major configuration system and architectural refactoring).
-**MPS Version Referenced:** v0.4.0 (Master Prompt Segment) and related component architecture (folder-per-app, `USER_appName_CONFIG.txt` standard, etc.).
-**Context/Scenario:** Planning the next development cycle for the MPS framework after successfully implementing a new configuration system and "folder-per-app" architecture.
-**Observation/Issue:**
-    1.  An existing internal "Concept task" (details to be provided by the user to the next Jules instance, potentially located in `Inputs/concept/inputs`) is currently monolithic and needs to be broken down into more manageable sub-tasks (approximately three).
-    2.  The process of decomposing and implementing these "Concept task" sub-tasks is expected to reveal opportunities or requirements for evolving the framework's current component definitions (add-on, util, process) or potentially introducing new component types or interaction paradigms.
-**Suggestion (For Next Jules Instance):**
-The next Jules instance should:
-    1.  **Gather Detailed Requirements for "Concept Task":** Actively engage with the user to obtain a detailed understanding of the current "Concept task," its goals, any existing materials (potentially in `Inputs/concept/inputs`).
-    2.  Collaborate with the user to define the three (approx.) sub-tasks for the "Concept task."
-    3.  In parallel, analyze how the requirements of these sub-tasks might necessitate extensions to the existing component concepts (add-on, util, process) or the introduction of new component types/paradigms within the MPS framework.
-    4.  Plan and implement both the "Concept task" restructuring and the identified framework component extensions, using the former as a practical test case for the latter.
----
-**Session Summary - 2025-06-03**
+**Session Summary - 2025-06-03 (Directive-Based Invocation)**
 **Instance:** Jules
 **User Feedback/Requests Addressed:**
-- User directed a new phase of MPS development focusing on two major initiatives:
-    1.  Abstracting the existing `build_product_specs_process` add-on into a more generic `create_research_report` add-on.
-    2.  Introducing a new "promptApp" concept to allow users to define and execute multi-stage workflows composed of underlying MPS components.
-- Clarified requirements for `create_research_report` parameters, including separate controls for `ITERATIVE_OUTPUT_DEPTH` (D0-D3 style) and `REFERENCE_FOLLOWING_DEPTH` (document link traversal).
-- Confirmed that plain text input formats (.txt, .md, web text) are the initial target for document processing.
-- Decided that sequential tasks within a `promptApp` will be handled by user re-invocation of new AI instances for each task, simplifying initial framework orchestration.
+- User proposed a new, simplified workflow for invoking the MPS framework.
+- Instead of users pasting the entire configured Master Prompt Segment into their initial interaction, they will prepare a single file in their repository (based on `Master_Prompt_Segment.txt` template) containing their high-level project request (wrapped in `[[USER_PROJECT_REQUEST]]` tags at the top) and all their MPS configurations (`[[USER_APP_SELECTION]]`, `[[USER_ADDON_SELECTION]]`, specific `[[USER_...CONFIGURATION]]` blocks, etc.).
+- The user will then invoke the AI system with a simple directive, e.g., `[[PROCESS_FRAMEWORK_INSTRUCTIONS FROM /path/to/their_configured_file.txt]]`.
+- The AI system is responsible for loading the specified file and making its content, including the prepended `[[USER_PROJECT_REQUEST]]` block, available for processing by `Core_Planning_Instructions.txt`.
+- This new directive method was also confirmed to be applicable for directly invoking utilities like `promptimizer`.
 
-**Summary of Approved Plan:**
-The overall plan involves:
-1.  Developing the `create_research_report` add-on (now complete).
-2.  Defining the "promptApp" structure and manifest file format.
-3.  Updating `Core_Planning_Instructions.txt` and `Master_Prompt_Segment.txt` to support `promptApp` discovery, selection, and execution.
-4.  Creating an initial structural example of a `promptApp` (`CompliancePLM`).
-5.  Retiring the `build_product_specs_process` add-on files.
-6.  Updating all documentation.
-7.  Testing the new functionalities.
-
-**Summary of Changes Made This Session (to implement Step 1 of the plan):**
--   **Created `prompts/add_ons/create_research_report/` directory.**
--   **Created `prompts/add_ons/create_research_report/USER_create_research_report_CONFIG.txt`:**
-    *   Defined parameters: `PROPOSED_TABLE_OF_CONTENTS`, `GUIDELINES_DOC_PATHS`, `ADDITIONAL_WEB_LINKS_FILE`, `EXEMPLAR_DOCS`, `GENERAL_INPUT_DOCS`, `PRIMARY_INPUT_DOC_PATH`, `ITERATIVE_OUTPUT_DEPTH`, `REFERENCE_FOLLOWING_DEPTH`, `PREVIOUS_ITERATION_OUTPUT_PATH`, `REPORT_BASENAME`, `REPORT_OUTPUT_PATH`.
-    *   Included full metadata (Requirement, DefaultType, Description, Default) for each.
--   **Created `prompts/add_ons/create_research_report/create_research_report.txt`:**
-    *   Adapted core logic from the former `build_product_specs_process.txt`.
-    *   Updated to use the new parameter set for generic report generation.
-    *   Removed product-specification-specific and detailed codebase review logic.
-    *   Maintained the 6-phase structure and parameter resolution mechanisms.
--   **Updated `prompts/add_ons/available_addons_manifest.md`:**
-    *   Added entry for `create_research_report`.
-    *   Removed entry for `build_product_specs_process`.
-
-**State of Deliverables:**
-- The `create_research_report` add-on (v0.1) is developed and its configuration file is in place.
-- The add-on manifest is updated.
-- The `build_product_specs_process` add-on is effectively replaced by this new add-on (physical file deletion is pending a later plan step).
-- Plan step 1 is complete.
-
-**Next Steps (This Jules instance/session):**
-- Proceed to Plan Step 2: "Define 'promptApp' Structure and Manifest." This involves designing the manifest file format that will define how `promptApps` (like the `CompliancePLM` example) are structured and how their tasks map to MPS components.
----
-**Session Summary - 2025-06-03 (Continued)**
-**Instance:** Jules
-**User Feedback/Requests Addressed (Post Initial 2025-06-03 Summary):**
-- User confirmed a critical change in component resolution strategy for `promptApps`: the search order should be "app-specific first" (flat file, then folder style within app), followed by global components (add-ons, then utils). This was a change from the initially implemented "globals first" approach.
-
-**Summary of Approved Plan (Revised Portion):**
-The plan was revised to implement and document this new search order:
-1.  Revise `Core_Planning_Instructions.txt` for the new "app-specific first" search order. (Completed)
-2.  Update `MPS_Usage_Guide.md` to reflect this new search order. (Completed)
-3.  Create test assets and conceptually outline tests for the new search order. (Completed)
-4.  Update `HANDOFF_NOTES.md` and submit. (This step)
-
-**Summary of Changes Made This Session (Implementing Revised Plan):**
--   **Modified `prompts/iep/Core_Planning_Instructions.txt`:**
-    *   Updated the component resolution logic in Section II.A.1.a.viii to implement the "app-specific first" search order:
-        1.  App-Specific (flat file): `prompts/apps/[Selected_PromptAppName]/[componentName].txt`
-        2.  App-Specific (folder style): `prompts/apps/[Selected_PromptAppName]/[componentName]/[componentName].txt`
-        3.  Global Add-on: `prompts/add_ons/[componentName]/[componentName].txt`
-        4.  Global Util: `prompts/util/[componentName]/[componentName].txt`
+**Summary of Changes Made This Session:**
+-   **Updated `prompts/iep/Core_Planning_Instructions.txt`:**
+    *   Verified/ensured a new Section I.A exists to parse the `[[USER_PROJECT_REQUEST]]` block from the beginning of the processed content and store it as `User_High_Level_Project_Goal`.
+    *   Adjusted subsequent sub-section lettering in Section I accordingly.
+-   **Updated Canonical `prompts/Master_Prompt_Segment.txt` Template:**
+    *   Added a prominent instructional comment block at the very top. This guides users to:
+        1. Copy the template to create their own project-specific MPS file.
+        2. Add their high-level project request (wrapped in `[[USER_PROJECT_REQUEST]]` tags) at the beginning of their file.
+        3. Edit all MPS configuration blocks within their file.
+        4. Use the `[[PROCESS_FRAMEWORK_INSTRUCTIONS FROM /path/to/their_file.txt]]` directive for AI invocation.
 -   **Updated `framework_dev_docs/guides/MPS_Usage_Guide.md`:**
-    *   Modified Section 3.B.2.i ("Component Resolution Search Order") and Section 4 ("Developing New promptApps") to accurately document the new "app-specific first" search order.
--   **Created Test Assets for Search Order Verification:**
-    *   Global add-on: `prompts/add_ons/test_resolver_component/` (with `test_resolver_component.txt` and `USER_...CONFIG.txt`).
-    *   App-specific component (folder style): `prompts/apps/CompliancePLM/test_resolver_component/` (with `test_resolver_component.txt` and `USER_...CONFIG.txt`).
-    *   Updated `prompts/add_ons/available_addons_manifest.md` for the global test component.
-    *   Updated `prompts/apps/CompliancePLM/CompliancePLM_manifest.json` to include a task "Test Component Resolution" that calls `test_resolver_component`.
+    *   Revised sections on setting up and invoking the MPS framework to detail the new directive-based workflow.
+    *   Explained how to prepare the single, comprehensive project-specific MPS file.
+    *   Clarified how the AI system handles the directive and makes the `[[USER_PROJECT_REQUEST]]` available.
+    *   Added a new subsection explaining how to use the directive to call specific utilities directly (e.g., `promptimizer.txt`), followed by the text input for that utility.
 
 **State of Deliverables:**
-- Core framework logic (`Core_Planning_Instructions.txt`) now correctly implements "app-specific first" component resolution for `promptApps`.
-- Documentation (`MPS_Usage_Guide.md`) accurately reflects this new search order.
-- Test assets are in place to verify this specific functionality.
-- The broader `promptApp` and `create_research_report` add-on implementation (from previous steps in this session) is complete.
-- The system is ready for user testing of the `promptApp` functionality, especially the component search order.
+- Core framework files (`Core_Planning_Instructions.txt`, `Master_Prompt_Segment.txt`) and the main usage guide (`MPS_Usage_Guide.md`) have been updated to support and document the new directive-based invocation workflow.
+- This simplifies the user's initial interaction with the AI system for MPS tasks.
 
 **Next Steps (User):**
-- Thoroughly test the `promptApp` system, focusing on:
-    - Invoking the "Test Component Resolution" task within `CompliancePLM` to ensure the app-specific `test_resolver_component` is used.
-    - Invoking tasks that use global components (like "Product Specification" using `create_research_report` in `CompliancePLM`) to ensure they are correctly found.
-    - Testing the iteration flow and re-invocation prompts for iterable tasks.
----
-**Session Summary - 2025-06-03 (Promptimizer Update)**
-**Instance:** Jules
-**User Feedback/Requests Addressed:**
-- User requested a sample for the `pre_flight_check_user_plan` utility.
-- Upon discussion, the utility was renamed to `promptimizer` for better clarity and branding.
-- A sample usage document for the newly named `promptimizer` utility was created.
-
-**Summary of Changes Made This Session:**
--   **Renamed Utility:**
-    *   The directory `prompts/util/pre_flight_check_user_plan/` was renamed to `prompts/util/promptimizer/`.
-    *   The file `pre_flight_check_user_plan.txt` within that directory was renamed to `promptimizer.txt`.
-    *   Internal text within `promptimizer.txt` (e.g., titles, role descriptions) was updated to reflect the new "Promptimizer" name and purpose (prompt optimization reviewer).
--   **Created Example Document:**
-    *   A new example file `framework_dev_docs/examples/promptimizer_example.md` was created.
-    *   This document explains how the `promptimizer.txt` utility is used (AI primed with the utility reviews a user's high-level request).
-    *   It includes a sample user project request with deliberate minor weaknesses.
-    *   It provides detailed example feedback that an AI, guided by `promptimizer.txt`, would generate, structured according to the utility's 7 feedback points.
-
-**State of Deliverables:**
-- The `promptimizer` utility is updated and an example of its usage is now available.
-- This concludes the requested work on samples for this session.
-
-**Next Steps (User):**
-- Review the `promptimizer_example.md`.
-- Consider if further refinements to the `promptimizer.txt` utility itself are desired (e.g., to have the AI proactively rewrite parts of the prompt).
----
-**Session Summary - 2025-06-03 (MPS Updater Plan)**
-**Instance:** Jules
-**User Feedback/Requests Addressed:**
-- User requested a mechanism to transfer MPS framework improvements/features between different instances/repositories.
-- This feature was named "MPS Updater" (MPU).
-- Instead of implementing MPU directly, the task was to formulate a detailed plan and create a prompt file for a *future* Jules instance to implement MPU.
-- The prompt for the future instance is to include an instruction for that instance to first review and refine the provided plan before implementation.
-
-**Summary of Changes Made This Session:**
--   **Formulated Detailed Plan for "MPS Updater" (MPU) Feature:**
-    *   Defined objectives for MPU.
-    *   Proposed "MPS Update Package" (MUP) formats, recommending a manifest-based approach for initial AI implementation, with standard `.patch` files as a more advanced alternative.
-    *   Outlined the conceptual design of an "Export MUP Package" utility (for the source repository, not for current implementation).
-    *   Designed the "Apply MPS Update Package" add-on (`apply_mps_update`):
-        *   Specified its location: `prompts/add_ons/apply_mps_update/`.
-        *   Detailed its `USER_apply_mps_update_CONFIG.txt` parameters (e.g., `MUP_PACKAGE_PATH`, `DRY_RUN_MODE`, `CONFLICT_RESOLUTION_STRATEGY`).
-        *   Outlined the phased logic for its `apply_mps_update.txt` instruction file (initialization, package parsing, pre-change analysis/dry run, change application, reporting/cleanup).
-    *   Emphasized the critical assumption of version synchronization between source and target repositories.
-    *   Defined initial scope for conflict handling (fail on conflict) and security considerations.
--   **Created Prompt File for Future Implementation:**
-    *   A new file `framework_dev_docs/meta/implement_mps_updater.txt` was created.
-    *   This file contains the comprehensive starting plan for the MPU feature as formulated above.
-    *   It includes an explicit instruction for the future implementing Jules instance to first review, critique, and refine the provided plan before starting its work.
-    *   It also outlines expected deliverables for the future instance (the add-on, documentation, tests, handoff notes).
-
-**State of Deliverables:**
-- A detailed plan and a directive prompt for implementing the "MPS Updater" feature by a future Jules instance have been created and saved to `framework_dev_docs/meta/implement_mps_updater.txt`.
-- No changes were made to the operational MPS framework components in this specific sub-task; the work was purely planning and documentation for a future task.
-
-**Next Steps (User):**
-- Review the `framework_dev_docs/meta/implement_mps_updater.txt` file.
-- When ready, assign the task described in that file to a new Jules instance.
----
-
-## MPS Performance Feedback Log
-
-This section logs specific feedback on the performance, clarity, and effectiveness of the Master Prompt Segment (MPS) versions and the artifacts they help generate.
-
----
-**Feedback Entry - 2023-11-02**
-**Source of Feedback:** Initial setup of this feedback log section during MPS feature design.
-**MPS Version Referenced:** Relevant for `prompts/Master_Prompt_Segment.txt` (v0.3.2 and future versions).
-**Context/Scenario:** Establishing the feedback mechanism as per design discussions for feature "Feedback Loop for MPS Refinement".
-**Observation/Issue:** This log is intended to capture issues like:
-    - Ambiguities in any version of `Master_Prompt_Segment.md` that lead to incorrect or suboptimal behavior by a Planning AI.
-    - Problems encountered by Task AIs due to the structure or content of prompts generated based on an MPS version.
-    - User difficulties in understanding or using the MPS, its generated `00_task_launch_plan.md`, or other artifacts.
-    - Success stories where a particular MPS instruction proved very effective.
-**Suggestion for MPS Refinement (if any):** N/A
----
-*(Future entries will be appended below this line)*
----
----
-**Feedback Entry Date:** 2023-10-27
-**Source of Feedback:** User (via direct request to Jules instance for refactoring).
-**MPS Version Referenced:** `prompts/Master_Prompt_Segment.txt` (approx. v0.3.2, prior to modularization) and the new modularized version (post this session's changes).
-**Context/Scenario:** User identified that the `Master_Prompt_Segment.txt` was becoming very long and dense, making it difficult to read, manage, and maintain.
-**Observation/Issue:** The monolithic nature of `Master_Prompt_Segment.txt` was impacting usability and the ease of making targeted changes to core planning instructions without affecting user-configurable sections.
-**Suggestion for MPS Refinement (Implemented):** To improve readability and maintainability, the core planning AI instructions were extracted from `Master_Prompt_Segment.txt` and placed into a new, dedicated file: `prompts/iep/Core_Planning_Instructions.txt`. The `Master_Prompt_Segment.txt` now includes these instructions using an `[[INCLUDE Core_Planning_Instructions.txt FROM /prompts/iep/Core_Planning_Instructions.txt]]` directive. This separation is intended to make both the user-facing configuration parts of the MPS and the core instructional logic easier to manage.
----
----
-**Feedback Entry Date:** 2023-10-27
-**Source of Feedback:** User (via direct request and illustrative example: `[ ] task_spawning_addon.txt` to Jules instance).
-**MPS Version Referenced:** The modularized MPS version (where `Core_Planning_Instructions.txt` was already separate) and the current version implementing optional task spawning via `task_spawning_addon.txt`.
-**Context/Scenario:** User desired to further enhance the framework's modularity by making the entire project planning and task generation process an optional component, selectable by the user, rather than an inherent, non-optional function of the MPS.
-**Observation/Issue:** While `Core_Planning_Instructions.txt` was already separated, it still implicitly mandated the task spawning workflow. The framework lacked the flexibility to be used for other purposes without invoking this primary planning behavior.
-**Suggestion for MPS Refinement (Implemented):** The user's suggestion to make task spawning an optional add-on was implemented.
-    - The core logic for project planning, TLP generation, and task prompt creation was moved from `prompts/iep/Core_Planning_Instructions.txt` to a new file: `prompts/add_ons/task_spawning_addon.txt`.
-    - `prompts/iep/Core_Planning_Instructions.txt` was updated to include conditional logic. It now checks if `task_spawning_addon.txt` is selected by the user in `[[USER_ADDON_SELECTION]]` (within `Master_Prompt_Segment.txt`).
-    - If selected, the `task_spawning_addon.txt` is executed.
-    - If not selected, the AI is instructed to acknowledge this, skip default plan generation, and process any other selected add-ons.
-    - This change makes the MPS framework significantly more flexible, allowing users to engage the Planning AI for potentially different primary functions by selecting different combinations of add-ons, or by using it with only utility add-ons.
----
----
-**Feedback Entry Date:** 2023-10-27
-**Source of Feedback:** User (clarifying questions and specific directive regarding `task_spawning_addon.txt` inheritance and add-on ordering).
-**MPS Version Referenced:** The MPS version with optional task spawning via `task_spawning_addon.txt`.
-**Context/Scenario:** User inquired about how multiple add-ons interact, particularly how `task_spawning_addon.txt` would affect other add-ons, and then specifically requested that `task_spawning_addon.txt` should not be inherited by the Task AIs it generates. User also sought clarity on the importance of add-on ordering in the selection block.
-**Observation/Issue:**
-    1. The previous add-on processing logic could have resulted in `task_spawning_addon.txt` (intended for the Planning AI) being appended to Task AI prompts, leading to overly verbose prompts and potential for unintended behavior.
-    2. The impact of add-on order in `[[USER_ADDON_SELECTION]]` on the final content of Task AI prompts was not explicitly documented, potentially leading to user confusion.
-**Suggestion for MPS Refinement (Implemented):**
-    - **Non-inheritance of `task_spawning_addon.txt`**: Modified `prompts/iep/Core_Planning_Instructions.txt` (Section I.B) to create a filtered list (`Inheritable_Addons_Content_Ordered_List`) of add-on contents for Task AI prompt inheritance, which explicitly excludes the content of `task_spawning_addon.txt`. This ensures the Planning AI uses `task_spawning_addon.txt` for its process, but Task AIs receive cleaner, more focused prompts.
-    - **Clarified Add-on Ordering**: Updated `prompts/Master_Prompt_Segment.txt` (comments in `[[USER_ADDON_SELECTION]]`) and `framework_dev_docs/guides/MPS_Usage_Guide.md` to explain that the order of inheritable add-ons is preserved when `task_spawning_addon.txt` appends them to task prompts. Also recommended listing `task_spawning_addon.txt` last for visual clarity if used.
-    - These refinements improve the safety and predictability of add-on interactions and provide users with better control and understanding of how their selections affect Task AI prompts.
----
----
-**Feedback Entry Date:** 2023-10-27
-**Source of Feedback:** User (initial idea for process automation, then specific refinements for primary input and reference depth for product specs).
-**MPS Version Referenced:** Current version with extensible primary add-on logic.
-**Context/Scenario:** User expressed a need to use the MPS framework for more than just task spawning, specifically for a structured process to generate product specification documents from various inputs. Later refinements included requests for more control over the research phase of this process.
-**Observation/Issue:** The initial MPS framework was primarily geared towards task spawning. A structured approach was needed to define and execute other complex, multi-step AI-driven processes. For the product specs process,
-        *   Added `PRODUCT_SPECS_PRIMARY_INPUT_FILE`: An optional path to a specific document. The AI is instructed to focus its research by analyzing at least every numbered heading in this document. If not provided, the AI selects the most comprehensive input document for this role.
-        *   Added `PRODUCT_SPECS_REF_DEPTH`: An optional integer (0-2, default 1) to control how many levels deep the AI will follow internal references within the provided document set.
-    These enhancements make the product specification generation process more guided and configurable.
----
----
-**Feedback Entry Date:** 2023-10-27
-**Source of Feedback:** Jules (proactive refinement during development of `build_product_specs_process.txt`).
-**MPS Version Referenced:** Current version with extensible primary add-on logic.
-**Context/Scenario:** The introduction of `build_product_specs_process.txt` as a new "primary directive" add-on (similar in role to `task_spawning_addon.txt` but with a different function) highlighted the need to generalize how the core framework selects and manages such add-ons.
-**Observation/Issue:** The existing logic in `prompts/iep/Core_Planning_Instructions.txt` was somewhat hardcoded around `task_spawning_addon.txt` for determining the main execution path and for non-inheritance of add-on content into sub-prompts. This would not scale well if many different primary add-ons were developed.
-**Suggestion for MPS Refinement (Implemented):**
-    - Modified `prompts/iep/Core_Planning_Instructions.txt` (Section I.B and II) to:
-        - Define a list of `Known_Primary_Directive_Addons`.
-        - Dynamically identify an `Active_Primary_Addon_Filename` by checking the user's selection against this known list, prioritizing the first one selected by the user if multiple are chosen. A warning is logged if multiple primary add-ons are selected.
-        - Ensure that the `Inheritable_Addons_Content_Ordered_List` (used for appending to sub-prompts) correctly excludes the content of the currently `Active_Primary_Addon_Filename`, not just `task_spawning_addon.txt`.
-    - This makes the core framework more robust and extensible, allowing new primary add-ons to be integrated more easily without requiring significant changes to the core conditional logic each time. It also handles user selection of multiple primary add-ons more gracefully.
----
----
-**Feedback Entry Date:** 2023-10-27
-**Source of Feedback:** User (specific feedback on research methodology, codebase interaction rules like "level 0 only for codebases," and codebase review preferences for the `build_product_specs_process.txt` add-on).
-**MPS Version Referenced:** Current version with `build_product_specs_process.txt` add-on.
-**Context/Scenario:** User provided detailed requirements to refine the initial `build_product_specs_process.txt` add-on to achieve a more structured, in-depth, and controllable research and content generation process, particularly focusing on how the AI should interact with a primary document and linked codebases.
-**Observation/Issue:** The initial version of `build_product_specs_process.txt` had a more general research phase. The user required a more granular, heading-based research approach for the Primary Input Document, specific rules for how the AI should analyze linked codebases (including different levels of review depth/focus), and a strict "level 0 only" rule for code analysis to prevent unintended deep dives into code.
-**Suggestion for MPS Refinement (Implemented):**
-The `prompts/add_ons/build_product_specs_process.txt` was significantly updated to incorporate the "Level 0 Deep Research" methodology as per user requirements:
-    - **New Configurations:** Introduced `PRODUCT_SPECS_CODEBASE_REVIEW_PREFERENCE` and `PRODUCT_SPECS_CODEBASE_FOCUS_AREAS` in `Master_Prompt_Segment.txt` and documented them in `MPS_Usage_Guide.md`.
-    - **Per-Heading Research Cycle:** The add-on's Phase 3 was restructured. It now includes an initial high-level review of the Primary Input Document. Then, for each major heading in that document, it performs a 5-step analysis: Heading Context Analysis, Supporting Docs Analysis, References & Codebase Analysis, Consolidated Research for the heading, and Iterative Content Contribution for that heading.
-    - **Codebase Review Integration:** The "References & Codebase Analysis" step now explicitly uses the `PRODUCT_SPECS_CODEBASE_REVIEW_PREFERENCE` ("complex", "cursory", "focused") and `PRODUCT_SPECS_CODEBASE_FOCUS_AREAS` to guide its interaction with linked code.
-    - **"Level 0 Code Analysis ONLY":** A strict rule was added, instructing the AI not to follow internal code references (like imports or function calls to other files) from any fetched code text. Its analysis is confined to the directly retrieved code content.
-    - **Iterative Content Drafting:** Content for output documents is now drafted iteratively during the per-heading analysis and then assembled and finalized in later phases.
-    This refined process provides a more systematic and controllable approach for the AI when generating product specifications.
----
----
-**Feedback Entry Date:** 2023-10-27
-**Source of Feedback:** User (clarifications and new requirements for iterative deepening for `build_product_specs_process.txt`).
-**MPS Version Referenced:** Current version with `build_product_specs_process.txt` add-on incorporating "Level 0 Deep Research".
-**Context/Scenario:** Expanding the iterative capabilities of `build_product_specs_process.txt` from an initial 0-2 level concept to a more detailed 0-3 level process with specific content goals for each level.
-**Observation/Issue:** The initial iterative deepening plan (0-2 levels) for `build_product_specs_process.txt` needed more specific content goals for each level and an additional level for AI-driven insights to meet user's evolving requirements for content depth and sophistication.
-**Suggestion for MPS Refinement (Implemented):**
-The iterative deepening feature of `build_product_specs_process.txt` was expanded to support 0-3 levels, and associated configurations and documentation were updated:
-    - **Configuration Updates (`Master_Prompt_Segment.txt`):** `PRODUCT_SPECS_ITERATION_DEPTH` comment updated to reflect the 0-3 range and specific goals:
-        - `0`: Outline Generation (headings with single key idea paragraphs).
-        - `1`: Basic Content (Bachelor's level, ~3 paras per D0 heading).
-        - `2`: Expert Elaboration (~1 page per original D0 heading).
-        - `3`: AI Unique Insights (~3 pages per original D0 heading, novel ideas).
-    - **Add-on Logic (`build_product_specs_process.txt`):**
-        - Phase 1 (Initialization) now validates depth (0-3) and `PRODUCT_SPECS_PREVIOUS_ITERATION_OUTPUT_PATH` (required for D1-D3, critical error if missing). Output file suffixes `_D0` to `_D3` are determined.
-        - Phase 2 (Input Processing) is conditional: D0 uses original inputs; D1-D3 use previous iteration's outputs as primary, with original inputs as reference.
-        - Phase 3 (Content Generation) has distinct logic for each depth (0-3), detailing how to build upon previous work (for D1-D3) or generate outlines (D0) according to the specified content goals for each level.
-    - **Documentation (`MPS_Usage_Guide.md`):** Updated to detail the 0-3 levels, their specific purposes, and the user workflow for managing iterative runs and output folders.
-    This provides a more granular, powerful, and well-defined iterative workflow for the `build_product_specs_process.txt` add-on.
----
----
-**Feedback Entry Date:** 2023-10-27
-**Source of Feedback:** User (vision for enhanced component modularity via "folder-per-app" architecture).
-**MPS Version Referenced:** Current version with multiple add-ons and utils.
-**Context/Scenario:** As the number of components (add-ons, utils, and potentially IPC handlers) grows, a flat file structure in their respective directories (`prompts/add_ons/`, `prompts/util/`) becomes less organized and limits the ability for components to have their own supporting files or sub-frameworks.
-**Observation/Issue:** The previous flat-file structure for add-ons and utils was not ideal for scalability or for components that might require multiple associated files (e.g., templates, data snippets, complex sub-instructions).
-**Suggestion for MPS Refinement (Implemented):**
-The framework was refactored to a "folder-per-app" architecture for all components (add-ons, utils, and anticipated IPC handlers):
-    - **Core Logic (`prompts/iep/Core_Planning_Instructions.txt`):** Updated to discover and load components based on a new directory structure.
-        - It now expects component-specific parent paths like `User_Path_Addons_Dir`, `User_Path_Utils_Dir`, `User_Path_IPC_Dir` to be defined in `[[USER PATH CONFIGURATION]]`.
-        - For each component "app" (e.g., `my_addon_app`), it looks for a subdirectory named `my_addon_app` within the relevant parent path.
-        - The primary instruction file for the app must be located at `[parent_path]/my_addon_app/my_addon_app.txt`.
-        - Internal references (e.g., `Known_Primary_Directive_Addon_Apps`, `Active_Primary_Addon_AppName`) now use these app/folder names.
-    - **Component Migration:** All existing add-ons (`task_spawning_addon`, `task_resumption_addon`, `build_product_specs_process`) and utils (`pre_flight_check_user_plan`) were moved into their respective new subdirectories (e.g., `prompts/add_ons/task_spawning_addon/task_spawning_addon.txt`).
-    - **New `prompts/ipc/` directory:** Created with a `.gitkeep` file for future IPC components.
-    - **Documentation Updates:**
-        - `prompts/add_ons/available_addons_manifest.md`: Updated to list add-ons by their app/folder name and describe the new structure.
-        - `framework_dev_docs/guides/MPS_Usage_Guide.md`: Comprehensively updated to explain the "folder-per-app" architecture, how users should set up paths, how components are selected, and how developers should structure new components.
-    This architectural change significantly improves modularity, organization, and the potential for more complex, self-contained components within the MPS framework.
----
----
-**Feedback Entry Date:** 2023-10-27
-**Source of Feedback:** User (desire to simplify MPS, new way to handle app-specific data, AI assistance for missing/default configs, specific format for detecting edits).
-**MPS Version Referenced:** v0.4.0 (Master Prompt Segment and Core Planning Instructions).
-**Context/Scenario:** This feedback entry summarizes a series of user requests and design discussions aimed at a comprehensive overhaul of the MPS framework's configuration system and a significant enhancement of the `build_product_specs_process` add-on's iterative capabilities.
-**Observation/Issue:**
-    1.  The global `[[USER PATH CONFIGURATION]]` in `Master_Prompt_Segment.txt` was becoming unwieldy; app-specific configs were mixed with global ones; parameter precedence and user edit detection were not formalized.
-    2.  A more structured and discoverable way to manage parameters for individual add-on apps was needed, including clear defaults and user override mechanisms.
-    3.  Users needed assistance in setting mandatory parameters, especially those with placeholder defaults.
-**Suggestion for MPS Refinement (Implemented):**
-A comprehensive refactoring of the configuration system was performed:
-    1.  **Fixed Global System Paths:** Core component discovery paths (for add-ons, utils, IEP, IPC) are now hardcoded in `Core_Planning_Instructions.txt`, simplifying user setup.
-    2.  **`[[USER PATH CONFIGURATION]]` Removed from `Master_Prompt_Segment.txt`:** This block was deleted. General output paths (like `Main Iteration Folder`) and other process-specific parameters are now intended to be managed as parameters within the configuration system of the relevant app.
-    3.  **App-Specific Configuration System:**
-        *   **`USER_appName_CONFIG.txt` Standard:** Defined a standard format for these template/storage files within each app's folder. This includes `[[USER_CONFIG_FOR_appName]]` delimiters, and per-parameter metadata (`# Requirement: [Required|Optional] | DefaultType: [Accepted|Placeholder]`), description with default (`# Description: ... Default: ...`), and the value line (`PARAM_NAME: [USER_VALUE_START]value[USER_VALUE_END]`).
-        *   **Main Prompt Overrides:** Users can copy the content of a `USER_appName_CONFIG.txt` into their main spawn prompt to provide run-specific overrides.
-        *   **Parameter Resolution Precedence:** Implemented in app logic (demonstrated in `build_product_specs_process.txt`): Main prompt block > User-edited `USER_appName_CONFIG.txt` > AcceptedDefault in `USER_appName_CONFIG.txt`.
-        *   **AI-Assisted Updates:** If a `Required` parameter with a `PlaceholderDefault` remains unresolved, the app instructs the AI (Jules) to request the value from the user via chat. The AI then updates the on-disk `USER_appName_CONFIG.txt` with the new value and outputs the complete updated config block for the user to transfer to their main spawn prompt.
-    4.  **Documentation:** All changes were reflected in `Master_Prompt_Segment.txt` (now v0.4.0), `Core_Planning_Instructions.txt`, `MPS_Usage_Guide.md`, and relevant add-on files (e.g., `build_product_specs_process/USER_build_product_specs_process_CONFIG.txt` and its primary instruction file).
-    This new system offers improved modularity, clarity in parameter management, and a better user experience through AI-assisted configuration.
----
----
-**Session Summary - 2023-10-27**
-**Instance:** Jules
-**Key Accomplishments This Session (Finalizing Configuration System & Preparing for "Concept Task" Handoff):**
-This session concluded the major refactoring of the MPS framework's configuration system and component architecture. It also prepared for the next phase of work focusing on the "Concept task."
-
-*   **Configuration System Refactoring (Completion & Documentation):**
-    *   **Standard for `USER_appName_CONFIG.txt`:** Formalized the standard for these files, including app-specific delimiters (`[[USER_CONFIG_FOR_appName]]`), and per-parameter metadata (`# Requirement: [Required|Optional] | DefaultType: [Accepted|Placeholder]`), descriptions, defaults, and `[USER_VALUE_START]...[USER_VALUE_END]` markers. An illustrative example (`USER_exampleApp_CONFIG.txt`) was created as part of this standard definition.
-    *   **Applied Standard:** The `build_product_specs_process` add-on's `USER_build_product_specs_process_CONFIG.txt` was updated to fully adhere to this new standard, with all its parameters classified.
-    *   **Refined App Logic (`build_product_specs_process.txt` v0.4):** Its parameter resolution logic in Phase 1 was enhanced to parse the new metadata from `USER_..._CONFIG.txt`. The AI-assisted update mechanism (asking user via chat) now correctly triggers only for "Required" parameters with "PlaceholderDefault" values that haven't been overridden. A final validation step ensures all "Required" parameters have valid values before proceeding, halting with an error if not.
-    *   **Streamlined `Master_Prompt_Segment.txt` (v0.4.0):** The global `[[USER PATH CONFIGURATION]]` block was definitively removed. Instructions in `[[USER_ADDON_SELECTION]]` were updated to guide users on app-specific configurations via `[[USER_CONFIG_FOR_appName]]` blocks in their main spawn prompt.
-    *   **Consolidated `MPS_Usage_Guide.md`:** The guide was thoroughly reviewed and updated to provide a comprehensive and consistent explanation of the new configuration system. This includes: fixed global system paths, the role and format of `USER_appName_CONFIG.txt` files, the user workflow for app configuration (using main prompt blocks or editing `USER_...CONFIG.txt`), the AI's parameter resolution precedence, and how AI-assisted updates work. The "folder-per-app" architecture is also clearly documented.
-
-*   **Next Area of Work (User Directed - For Next Jules Instance):**
-    *   The user has directed focus towards refining an existing "Concept task."
-    *   This will involve analyzing the "Concept task" and splitting it into approximately three sub-tasks.
-    *   A key aspect of this work will be to use the "Concept task" sub-tasks as a practical use case for **exploring and implementing extensions to the 'add-on, util, and process' component concepts** within the MPS framework.
-    *   The next Jules instance is tasked with initiating this by requesting detailed requirements from the user regarding the "Concept task" (current state, materials possibly in `Inputs/concept/inputs`, ideas for sub-tasks) and their initial thoughts on evolving the component model.
-
-**State of Deliverables:**
-The comprehensive refactoring of the MPS configuration system is complete. This includes the "folder-per-app" architecture, fixed system paths for component discovery, and the new app-specific configuration mechanism using `USER_appName_CONFIG.txt` files and `[[USER_CONFIG_FOR_appName]]` blocks, featuring AI-assisted updates. All core prompts and documentation (`Master_Prompt_Segment.txt`, `Core_Planning_Instructions.txt`, `MPS_Usage_Guide.md`, `available_addons_manifest.md`, and relevant add-ons like `build_product_specs_process`) have been updated to reflect these changes. The framework is significantly more modular, user-friendly, and robust in its configuration management. No new code or prompt changes were made in this specific summarization step. The system is ready for handoff to the next Jules instance to begin work on the "Concept task" and component model evolution.
----
----
-**Feedback Entry Date:** 2025-06-02
-**Source of Feedback:** User (new directive for next area of work following completion of major configuration system and architectural refactoring).
-**MPS Version Referenced:** v0.4.0 (Master Prompt Segment) and related component architecture (folder-per-app, `USER_appName_CONFIG.txt` standard, etc.).
-**Context/Scenario:** Planning the next development cycle for the MPS framework after successfully implementing a new configuration system and "folder-per-app" architecture.
-**Observation/Issue:**
-    1.  An existing internal "Concept task" (details to be provided by the user to the next Jules instance, potentially located in `Inputs/concept/inputs`) is currently monolithic and needs to be broken down into more manageable sub-tasks (approximately three).
-    2.  The process of decomposing and implementing these "Concept task" sub-tasks is expected to reveal opportunities or requirements for evolving the framework's current component definitions (add-on, util, process) or potentially introducing new component types or interaction paradigms.
-**Suggestion (For Next Jules Instance):**
-The next Jules instance should:
-    1.  **Gather Detailed Requirements for "Concept Task":** Actively engage with the user to obtain a detailed understanding of the current "Concept task," its goals, any existing materials (potentially in `Inputs/concept/inputs`).
-    2.  Collaborate with the user to define the three (approx.) sub-tasks for the "Concept task."
-    3.  In parallel, analyze how the requirements of these sub-tasks might necessitate extensions to the existing component concepts (add-on, util, process) or the introduction of new component types/paradigms within the MPS framework.
-    4.  Plan and implement both the "Concept task" restructuring and the identified framework component extensions, using the former as a practical test case for the latter.
----
-**Session Summary - 2025-06-03**
-**Instance:** Jules
-**User Feedback/Requests Addressed:**
-- User directed a new phase of MPS development focusing on two major initiatives:
-    1.  Abstracting the existing `build_product_specs_process` add-on into a more generic `create_research_report` add-on.
-    2.  Introducing a new "promptApp" concept to allow users to define and execute multi-stage workflows composed of underlying MPS components.
-- Clarified requirements for `create_research_report` parameters, including separate controls for `ITERATIVE_OUTPUT_DEPTH` (D0-D3 style) and `REFERENCE_FOLLOWING_DEPTH` (document link traversal).
-- Confirmed that plain text input formats (.txt, .md, web text) are the initial target for document processing.
-- Decided that sequential tasks within a `promptApp` will be handled by user re-invocation of new AI instances for each task, simplifying initial framework orchestration.
-
-**Summary of Approved Plan:**
-The overall plan involves:
-1.  Developing the `create_research_report` add-on (now complete).
-2.  Defining the "promptApp" structure and manifest file format.
-3.  Updating `Core_Planning_Instructions.txt` and `Master_Prompt_Segment.txt` to support `promptApp` discovery, selection, and execution.
-4.  Creating an initial structural example of a `promptApp` (`CompliancePLM`).
-5.  Retiring the `build_product_specs_process` add-on files.
-6.  Updating all documentation.
-7.  Testing the new functionalities.
-
-**Summary of Changes Made This Session (to implement Step 1 of the plan):**
--   **Created `prompts/add_ons/create_research_report/` directory.**
--   **Created `prompts/add_ons/create_research_report/USER_create_research_report_CONFIG.txt`:**
-    *   Defined parameters: `PROPOSED_TABLE_OF_CONTENTS`, `GUIDELINES_DOC_PATHS`, `ADDITIONAL_WEB_LINKS_FILE`, `EXEMPLAR_DOCS`, `GENERAL_INPUT_DOCS`, `PRIMARY_INPUT_DOC_PATH`, `ITERATIVE_OUTPUT_DEPTH`, `REFERENCE_FOLLOWING_DEPTH`, `PREVIOUS_ITERATION_OUTPUT_PATH`, `REPORT_BASENAME`, `REPORT_OUTPUT_PATH`.
-    *   Included full metadata (Requirement, DefaultType, Description, Default) for each.
--   **Created `prompts/add_ons/create_research_report/create_research_report.txt`:**
-    *   Adapted core logic from the former `build_product_specs_process.txt`.
-    *   Updated to use the new parameter set for generic report generation.
-    *   Removed product-specification-specific and detailed codebase review logic.
-    *   Maintained the 6-phase structure and parameter resolution mechanisms.
--   **Updated `prompts/add_ons/available_addons_manifest.md`:**
-    *   Added entry for `create_research_report`.
-    *   Removed entry for `build_product_specs_process`.
-
-**State of Deliverables:**
-- The `create_research_report` add-on (v0.1) is developed and its configuration file is in place.
-- The add-on manifest is updated.
-- The `build_product_specs_process` add-on is effectively replaced by this new add-on (physical file deletion is pending a later plan step).
-- Plan step 1 is complete.
-
-**Next Steps (This Jules instance/session):**
-- Proceed to Plan Step 2: "Define 'promptApp' Structure and Manifest." This involves designing the manifest file format that will define how `promptApps` (like the `CompliancePLM` example) are structured and how their tasks map to MPS components.
----
-**Session Summary - 2025-06-03 (Continued)**
-**Instance:** Jules
-**User Feedback/Requests Addressed (Post Initial 2025-06-03 Summary):**
-- User confirmed a critical change in component resolution strategy for `promptApps`: the search order should be "app-specific first" (flat file, then folder style within app), followed by global components (add-ons, then utils). This was a change from the initially implemented "globals first" approach.
-
-**Summary of Approved Plan (Revised Portion):**
-The plan was revised to implement and document this new search order:
-1.  Revise `Core_Planning_Instructions.txt` for the new "app-specific first" search order. (Completed)
-2.  Update `MPS_Usage_Guide.md` to reflect this new search order. (Completed)
-3.  Create test assets and conceptually outline tests for the new search order. (Completed)
-4.  Update `HANDOFF_NOTES.md` and submit. (This step)
-
-**Summary of Changes Made This Session (Implementing Revised Plan):**
--   **Modified `prompts/iep/Core_Planning_Instructions.txt`:**
-    *   Updated the component resolution logic in Section II.A.1.a.viii to implement the "app-specific first" search order:
-        1.  App-Specific (flat file): `prompts/apps/[Selected_PromptAppName]/[componentName].txt`
-        2.  App-Specific (folder style): `prompts/apps/[Selected_PromptAppName]/[componentName]/[componentName].txt`
-        3.  Global Add-on: `prompts/add_ons/[componentName]/[componentName].txt`
-        4.  Global Util: `prompts/util/[componentName]/[componentName].txt`
--   **Updated `framework_dev_docs/guides/MPS_Usage_Guide.md`:**
-    *   Modified Section 3.B.2.i ("Component Resolution Search Order") and Section 4 ("Developing New promptApps") to accurately document the new "app-specific first" search order.
--   **Created Test Assets for Search Order Verification:**
-    *   Global add-on: `prompts/add_ons/test_resolver_component/` (with `test_resolver_component.txt` and `USER_...CONFIG.txt`).
-    *   App-specific component (folder style): `prompts/apps/CompliancePLM/test_resolver_component/` (with `test_resolver_component.txt` and `USER_...CONFIG.txt`).
-    *   Updated `prompts/add_ons/available_addons_manifest.md` for the global test component.
-    *   Updated `prompts/apps/CompliancePLM/CompliancePLM_manifest.json` to include a task "Test Component Resolution" that calls `test_resolver_component`.
-
-**State of Deliverables:**
-- Core framework logic (`Core_Planning_Instructions.txt`) now correctly implements "app-specific first" component resolution for `promptApps`.
-- Documentation (`MPS_Usage_Guide.md`) accurately reflects this new search order.
-- Test assets are in place to verify this specific functionality.
-- The broader `promptApp` and `create_research_report` add-on implementation (from previous steps in this session) is complete.
-- The system is ready for user testing of the `promptApp` functionality, especially the component search order.
-
-**Next Steps (User):**
-- Thoroughly test the `promptApp` system, focusing on:
-    - Invoking the "Test Component Resolution" task within `CompliancePLM` to ensure the app-specific `test_resolver_component` is used.
-    - Invoking tasks that use global components (like "Product Specification" using `create_research_report` in `CompliancePLM`) to ensure they are correctly found.
-    - Testing the iteration flow and re-invocation prompts for iterable tasks.
----
-**Session Summary - 2025-06-03 (Promptimizer Update)**
-**Instance:** Jules
-**User Feedback/Requests Addressed:**
-- User requested a sample for the `pre_flight_check_user_plan` utility.
-- Upon discussion, the utility was renamed to `promptimizer` for better clarity and branding.
-- A sample usage document for the newly named `promptimizer` utility was created.
-
-**Summary of Changes Made This Session:**
--   **Renamed Utility:**
-    *   The directory `prompts/util/pre_flight_check_user_plan/` was renamed to `prompts/util/promptimizer/`.
-    *   The file `pre_flight_check_user_plan.txt` within that directory was renamed to `promptimizer.txt`.
-    *   Internal text within `promptimizer.txt` (e.g., titles, role descriptions) was updated to reflect the new "Promptimizer" name and purpose (prompt optimization reviewer).
--   **Created Example Document:**
-    *   A new example file `framework_dev_docs/examples/promptimizer_example.md` was created.
-    *   This document explains how the `promptimizer.txt` utility is used (AI primed with the utility reviews a user's high-level request).
-    *   It includes a sample user project request with deliberate minor weaknesses.
-    *   It provides detailed example feedback that an AI, guided by `promptimizer.txt`, would generate, structured according to the utility's 7 feedback points.
-
-**State of Deliverables:**
-- The `promptimizer` utility is updated and an example of its usage is now available.
-- This concludes the requested work on samples for this session.
-
-**Next Steps (User):**
-- Review the `promptimizer_example.md`.
-- Consider if further refinements to the `promptimizer.txt` utility itself are desired (e.g., to have the AI proactively rewrite parts of the prompt).
----
-**Session Summary - 2025-06-03 (MPS Updater Plan)**
-**Instance:** Jules
-**User Feedback/Requests Addressed:**
-- User requested a mechanism to transfer MPS framework improvements/features between different instances/repositories.
-- This feature was named "MPS Updater" (MPU).
-- Instead of implementing MPU directly, the task was to formulate a detailed plan and create a prompt file for a *future* Jules instance to implement MPU.
-- The prompt for the future instance is to include an instruction for that instance to first review and refine the provided plan before implementation.
-
-**Summary of Changes Made This Session:**
--   **Formulated Detailed Plan for "MPS Updater" (MPU) Feature:**
-    *   Defined objectives for MPU.
-    *   Proposed "MPS Update Package" (MUP) formats, recommending a manifest-based approach for initial AI implementation, with standard `.patch` files as a more advanced alternative.
-    *   Outlined the conceptual design of an "Export MUP Package" utility (for the source repository, not for current implementation).
-    *   Designed the "Apply MPS Update Package" add-on (`apply_mps_update`):
-        *   Specified its location: `prompts/add_ons/apply_mps_update/`.
-        *   Detailed its `USER_apply_mps_update_CONFIG.txt` parameters (e.g., `MUP_PACKAGE_PATH`, `DRY_RUN_MODE`, `CONFLICT_RESOLUTION_STRATEGY`).
-        *   Outlined the phased logic for its `apply_mps_update.txt` instruction file (initialization, package parsing, pre-change analysis/dry run, change application, reporting/cleanup).
-    *   Emphasized the critical assumption of version synchronization between source and target repositories.
-    *   Defined initial scope for conflict handling (fail on conflict) and security considerations.
--   **Created Prompt File for Future Implementation:**
-    *   A new file `framework_dev_docs/meta/implement_mps_updater.txt` was created.
-    *   This file contains the comprehensive starting plan for the MPU feature as formulated above.
-    *   It includes an explicit instruction for the future implementing Jules instance to first review, critique, and refine the provided plan before starting its work.
-    *   It also outlines expected deliverables for the future instance (the add-on, documentation, tests, handoff notes).
-
-**State of Deliverables:**
-- A detailed plan and a directive prompt for implementing the "MPS Updater" feature by a future Jules instance have been created and saved to `framework_dev_docs/meta/implement_mps_updater.txt`.
-- No changes were made to the operational MPS framework components in this specific sub-task; the work was purely planning and documentation for a future task.
-
-**Next Steps (User):**
-- Review the `framework_dev_docs/meta/implement_mps_updater.txt` file.
-- When ready, assign the task described in that file to a new Jules instance.
+- Review all updated documentation for clarity and accuracy.
+- Test the new directive-based workflow thoroughly with various scenarios, including:
+    - Main MPS planning via a user-prepared project instruction file.
+    - Direct utility invocation (e.g., with `promptimizer`).
 ---
 
 ## MPS Performance Feedback Log
@@ -1434,6 +807,41 @@ The plan was revised to implement and document this new search order:
 - Review the `framework_dev_docs/meta/implement_mps_updater.txt` file.
 - When ready, assign the task described in that file to a new Jules instance.
 ---
+**Session Summary - 2025-06-03 (Directive-Based Invocation)**
+**Instance:** Jules
+**User Feedback/Requests Addressed:**
+- User proposed a new, simplified workflow for invoking the MPS framework.
+- Instead of users pasting the entire configured Master Prompt Segment into their initial interaction, they will prepare a single file in their repository (based on `Master_Prompt_Segment.txt` template) containing their high-level project request (wrapped in `[[USER_PROJECT_REQUEST]]` tags at the top) and all their MPS configurations (`[[USER_APP_SELECTION]]`, `[[USER_ADDON_SELECTION]]`, specific `[[USER_...CONFIGURATION]]` blocks, etc.).
+- The user will then invoke the AI system with a simple directive, e.g., `[[PROCESS_FRAMEWORK_INSTRUCTIONS FROM /path/to/their_configured_file.txt]]`.
+- The AI system is responsible for loading the specified file and making its content, including the prepended `[[USER_PROJECT_REQUEST]]` block, available for processing by `Core_Planning_Instructions.txt`.
+- This new directive method was also confirmed to be applicable for directly invoking utilities like `promptimizer`.
+
+**Summary of Changes Made This Session:**
+-   **Updated `prompts/iep/Core_Planning_Instructions.txt`:**
+    *   Verified/ensured a new Section I.A exists to parse the `[[USER_PROJECT_REQUEST]]` block from the beginning of the processed content and store it as `User_High_Level_Project_Goal`.
+    *   Adjusted subsequent sub-section lettering in Section I accordingly.
+-   **Updated Canonical `prompts/Master_Prompt_Segment.txt` Template:**
+    *   Added a prominent instructional comment block at the very top. This guides users to:
+        1. Copy the template to create their own project-specific MPS file.
+        2. Add their high-level project request (wrapped in `[[USER_PROJECT_REQUEST]]` tags) at the beginning of their file.
+        3. Edit all MPS configuration blocks within their file.
+        4. Use the `[[PROCESS_FRAMEWORK_INSTRUCTIONS FROM /path/to/their_file.txt]]` directive for AI invocation.
+-   **Updated `framework_dev_docs/guides/MPS_Usage_Guide.md`:**
+    *   Revised sections on setting up and invoking the MPS framework to detail the new directive-based workflow.
+    *   Explained how to prepare the single, comprehensive project-specific MPS file.
+    *   Clarified how the AI system handles the directive and makes the `[[USER_PROJECT_REQUEST]]` available.
+    *   Added a new subsection explaining how to use the directive to call specific utilities directly (e.g., `promptimizer.txt`), followed by the text input for that utility.
+
+**State of Deliverables:**
+- Core framework files (`Core_Planning_Instructions.txt`, `Master_Prompt_Segment.txt`) and the main usage guide (`MPS_Usage_Guide.md`) have been updated to support and document the new directive-based invocation workflow.
+- This simplifies the user's initial interaction with the AI system for MPS tasks.
+
+**Next Steps (User):**
+- Review all updated documentation for clarity and accuracy.
+- Test the new directive-based workflow thoroughly with various scenarios, including:
+    - Main MPS planning via a user-prepared project instruction file.
+    - Direct utility invocation (e.g., with `promptimizer`).
+---
 
 ## MPS Performance Feedback Log
 
@@ -1765,6 +1173,41 @@ The plan was revised to implement and document this new search order:
 - Review the `framework_dev_docs/meta/implement_mps_updater.txt` file.
 - When ready, assign the task described in that file to a new Jules instance.
 ---
+**Session Summary - 2025-06-03 (Directive-Based Invocation)**
+**Instance:** Jules
+**User Feedback/Requests Addressed:**
+- User proposed a new, simplified workflow for invoking the MPS framework.
+- Instead of users pasting the entire configured Master Prompt Segment into their initial interaction, they will prepare a single file in their repository (based on `Master_Prompt_Segment.txt` template) containing their high-level project request (wrapped in `[[USER_PROJECT_REQUEST]]` tags at the top) and all their MPS configurations (`[[USER_APP_SELECTION]]`, `[[USER_ADDON_SELECTION]]`, specific `[[USER_...CONFIGURATION]]` blocks, etc.).
+- The user will then invoke the AI system with a simple directive, e.g., `[[PROCESS_FRAMEWORK_INSTRUCTIONS FROM /path/to/their_configured_file.txt]]`.
+- The AI system is responsible for loading the specified file and making its content, including the prepended `[[USER_PROJECT_REQUEST]]` block, available for processing by `Core_Planning_Instructions.txt`.
+- This new directive method was also confirmed to be applicable for directly invoking utilities like `promptimizer`.
+
+**Summary of Changes Made This Session:**
+-   **Updated `prompts/iep/Core_Planning_Instructions.txt`:**
+    *   Verified/ensured a new Section I.A exists to parse the `[[USER_PROJECT_REQUEST]]` block from the beginning of the processed content and store it as `User_High_Level_Project_Goal`.
+    *   Adjusted subsequent sub-section lettering in Section I accordingly.
+-   **Updated Canonical `prompts/Master_Prompt_Segment.txt` Template:**
+    *   Added a prominent instructional comment block at the very top. This guides users to:
+        1. Copy the template to create their own project-specific MPS file.
+        2. Add their high-level project request (wrapped in `[[USER_PROJECT_REQUEST]]` tags) at the beginning of their file.
+        3. Edit all MPS configuration blocks within their file.
+        4. Use the `[[PROCESS_FRAMEWORK_INSTRUCTIONS FROM /path/to/their_file.txt]]` directive for AI invocation.
+-   **Updated `framework_dev_docs/guides/MPS_Usage_Guide.md`:**
+    *   Revised sections on setting up and invoking the MPS framework to detail the new directive-based workflow.
+    *   Explained how to prepare the single, comprehensive project-specific MPS file.
+    *   Clarified how the AI system handles the directive and makes the `[[USER_PROJECT_REQUEST]]` available.
+    *   Added a new subsection explaining how to use the directive to call specific utilities directly (e.g., `promptimizer.txt`), followed by the text input for that utility.
+
+**State of Deliverables:**
+- Core framework files (`Core_Planning_Instructions.txt`, `Master_Prompt_Segment.txt`) and the main usage guide (`MPS_Usage_Guide.md`) have been updated to support and document the new directive-based invocation workflow.
+- This simplifies the user's initial interaction with the AI system for MPS tasks.
+
+**Next Steps (User):**
+- Review all updated documentation for clarity and accuracy.
+- Test the new directive-based workflow thoroughly with various scenarios, including:
+    - Main MPS planning via a user-prepared project instruction file.
+    - Direct utility invocation (e.g., with `promptimizer`).
+---
 
 ## MPS Performance Feedback Log
 
@@ -2096,6 +1539,41 @@ The plan was revised to implement and document this new search order:
 - Review the `framework_dev_docs/meta/implement_mps_updater.txt` file.
 - When ready, assign the task described in that file to a new Jules instance.
 ---
+**Session Summary - 2025-06-03 (Directive-Based Invocation)**
+**Instance:** Jules
+**User Feedback/Requests Addressed:**
+- User proposed a new, simplified workflow for invoking the MPS framework.
+- Instead of users pasting the entire configured Master Prompt Segment into their initial interaction, they will prepare a single file in their repository (based on `Master_Prompt_Segment.txt` template) containing their high-level project request (wrapped in `[[USER_PROJECT_REQUEST]]` tags at the top) and all their MPS configurations (`[[USER_APP_SELECTION]]`, `[[USER_ADDON_SELECTION]]`, specific `[[USER_...CONFIGURATION]]` blocks, etc.).
+- The user will then invoke the AI system with a simple directive, e.g., `[[PROCESS_FRAMEWORK_INSTRUCTIONS FROM /path/to/their_configured_file.txt]]`.
+- The AI system is responsible for loading the specified file and making its content, including the prepended `[[USER_PROJECT_REQUEST]]` block, available for processing by `Core_Planning_Instructions.txt`.
+- This new directive method was also confirmed to be applicable for directly invoking utilities like `promptimizer`.
+
+**Summary of Changes Made This Session:**
+-   **Updated `prompts/iep/Core_Planning_Instructions.txt`:**
+    *   Verified/ensured a new Section I.A exists to parse the `[[USER_PROJECT_REQUEST]]` block from the beginning of the processed content and store it as `User_High_Level_Project_Goal`.
+    *   Adjusted subsequent sub-section lettering in Section I accordingly.
+-   **Updated Canonical `prompts/Master_Prompt_Segment.txt` Template:**
+    *   Added a prominent instructional comment block at the very top. This guides users to:
+        1. Copy the template to create their own project-specific MPS file.
+        2. Add their high-level project request (wrapped in `[[USER_PROJECT_REQUEST]]` tags) at the beginning of their file.
+        3. Edit all MPS configuration blocks within their file.
+        4. Use the `[[PROCESS_FRAMEWORK_INSTRUCTIONS FROM /path/to/their_file.txt]]` directive for AI invocation.
+-   **Updated `framework_dev_docs/guides/MPS_Usage_Guide.md`:**
+    *   Revised sections on setting up and invoking the MPS framework to detail the new directive-based workflow.
+    *   Explained how to prepare the single, comprehensive project-specific MPS file.
+    *   Clarified how the AI system handles the directive and makes the `[[USER_PROJECT_REQUEST]]` available.
+    *   Added a new subsection explaining how to use the directive to call specific utilities directly (e.g., `promptimizer.txt`), followed by the text input for that utility.
+
+**State of Deliverables:**
+- Core framework files (`Core_Planning_Instructions.txt`, `Master_Prompt_Segment.txt`) and the main usage guide (`MPS_Usage_Guide.md`) have been updated to support and document the new directive-based invocation workflow.
+- This simplifies the user's initial interaction with the AI system for MPS tasks.
+
+**Next Steps (User):**
+- Review all updated documentation for clarity and accuracy.
+- Test the new directive-based workflow thoroughly with various scenarios, including:
+    - Main MPS planning via a user-prepared project instruction file.
+    - Direct utility invocation (e.g., with `promptimizer`).
+---
 
 ## MPS Performance Feedback Log
 
@@ -2392,4 +1870,13 @@ The plan was revised to implement and document this new search order:
 
 **Next Steps (User):**
 - Review the `promptimizer_example.md`.
-- Consider if further refinements to the `promptimizer.txt` utility itself are desired (e.
+- Consider if further refinements to the `promptimizer.txt` utility itself are desired (e.g., to have the AI proactively rewrite parts of the prompt).
+---
+**Session Summary - 2025-06-03 (MPS Updater Plan)**
+**Instance:** Jules
+**User Feedback/Requests Addressed:**
+- User requested a mechanism to transfer MPS framework improvements/features between different instances/repositories.
+- This feature was named "MPS Updater" (MPU).
+- Instead of implementing MPU directly, the task was to formulate a detailed plan and create a prompt file for a *future* Jules instance to implement MPU.
+- The prompt for the future instance is to include an instruction for
+[end of framework_dev_docs/meta/HANDOFF_NOTES.md]

--- a/prompts/Master_Prompt_Segment.txt
+++ b/prompts/Master_Prompt_Segment.txt
@@ -1,3 +1,45 @@
+# === MPS TEMPLATE INSTRUCTIONS FOR USER ===
+#
+# This file (`Master_Prompt_Segment.txt`) is a template. To use the MPS framework:
+#
+# 1. **COPY TO YOUR PROJECT:**
+#    Copy the entire content of this file into a new file within your own project's
+#    `prompts` directory (e.g., `my_project_repo/prompts/my_project_main_mps.txt`).
+#
+# 2. **ADD YOUR PROJECT REQUEST (IN YOUR COPY):**
+#    At the VERY BEGINNING of your new file (e.g., `my_project_main_mps.txt`),
+#    add your high-level project request. It is **highly recommended** to wrap
+#    your request in `[[USER_PROJECT_REQUEST]]` and `[[END_USER_PROJECT_REQUEST]]` tags.
+#    For example:
+#
+#    [[USER_PROJECT_REQUEST]]
+#    My project is to design and plan for a new automated hydroponics system
+#    for urban farming, focusing on modularity and water efficiency.
+#    [[END_USER_PROJECT_REQUEST]]
+#
+#    (The rest of this template's content, starting with `[[USER_APP_SELECTION]]`
+#    or other initial blocks, should follow immediately after your project request.)
+#
+# 3. **CONFIGURE YOUR MPS FILE (IN YOUR COPY):**
+#    Edit the user configuration blocks within your new file as needed:
+#    *   `[[USER_APP_SELECTION]]`: Select a promptApp if you are using one.
+#    *   `[[USER_ADDON_SELECTION]]`: Select standalone add-ons if not using a promptApp.
+#    *   `[[USER_promptAPP_NAME_CONFIGURATION]]`: If you selected a promptApp, define
+#       which of its tasks to run. (See examples in this template).
+#    *   `[[USER_CONFIG_FOR_componentName]]`: Provide specific configurations for
+#       any components that require them.
+#
+# 4. **INVOKE THE MPS FRAMEWORK (YOUR ACTUAL PROMPT TO THE AI SYSTEM):**
+#    Your actual prompt to the AI planning system will then be a single directive
+#    pointing to YOUR prepared file. For example:
+#
+#    `[[PROCESS_FRAMEWORK_INSTRUCTIONS FROM /prompts/my_project_main_mps.txt]]`
+#
+#    The AI system will load your file, find your project request within the
+#    `[[USER_PROJECT_REQUEST]]` tags, and then process your MPS configurations.
+#
+# === END OF MPS TEMPLATE INSTRUCTIONS ===
+
 [[USER_APP_SELECTION]]
 # Instructions for user:
 # - List desired "promptApp" names below, one per line.

--- a/prompts/iep/Core_Planning_Instructions.txt
+++ b/prompts/iep/Core_Planning_Instructions.txt
@@ -1,12 +1,25 @@
 **I. USER-CONFIGURED PATHS, ADD-ON SELECTION, COMPONENT DISCOVERY & LOADING:**
 
-A. **Parse User-Configured Paths for Outputs and Specific Inputs:**
+A. **Extract User's High-Level Project Request:**
+    1.  Initialize `User_High_Level_Project_Goal`: `null` (or an empty string).
+    2.  Define delimiters: `start_req_delim = "[[USER_PROJECT_REQUEST]]"`, `end_req_delim = "[[END_USER_PROJECT_REQUEST]]"`.
+    3.  Search the *entire current processing content* (which the AI system is assumed to have prepared by combining the user's initial raw request with the user's configured MPS file loaded via a directive) for text between these delimiters.
+    4.  If found:
+        a.  Extract the raw string content (exclusive of the delimiters, trim leading/trailing whitespace).
+        b.  Store this extracted content as `User_High_Level_Project_Goal`.
+        c.  INFO "User High-Level Project Goal successfully extracted."
+    5.  If not found OR if the extracted content is empty or only whitespace:
+        a.  WARNING "[[USER_PROJECT_REQUEST]] block not found or empty. The primary project goal may be missing. Subsequent planning processes might rely on user input provided through other configuration means (e.g., within component-specific parameters) or may require clarification."
+        b.  `User_High_Level_Project_Goal` remains `null` or is set to a specific "not_found_or_empty" marker string.
+    6.  The `User_High_Level_Project_Goal` (or its not-found status) should be accessible by primary directive components (e.g., the component for a selected promptApp task, or a selected primary add-on like `task_spawning_addon` or `create_research_report`) for their main planning or processing context. These components will be responsible for checking if the goal is sufficiently defined for their needs.
+
+B. **Parse User-Configured Paths for Outputs and Specific Inputs:**
     You **must** parse the `[[USER PATH CONFIGURATION]]` block if it is found at the very beginning of *this Master Prompt Segment*. These paths are primarily for directing your outputs and locating some user-provided process-specific inputs.
     *   **Note:** This section is largely deprecated with the move to app-specific configurations and fixed system paths. However, if legacy path configurations are found, they might be used by older components. Modern components should rely on their own `USER_..._CONFIG.txt` files for path parameters.
     *   If any output/process-specific paths are required by an active component and not found in its dedicated configuration, that component must define its own default behavior or error handling.
     *   All paths you generate for outputs must be constructed clearly, typically relative to the repository root.
 
-B. **Fixed Global System Paths for Core Components:**
+C. **Fixed Global System Paths for Core Components:**
     The locations for core framework components (PromptApps, Add-ons, Utils, Base IEP, IPC directory) are fixed and relative to the repository root. You **must** use these hardcoded paths for discovery and loading:
     *   **PromptApps Base Directory:** `prompts/apps/`
     *   **Add-ons Base Directory:** `prompts/add_ons/`
@@ -14,7 +27,7 @@ B. **Fixed Global System Paths for Core Components:**
     *   **IEP Base Directory:** `prompts/iep/` (specifically for `Base_IEP.txt`)
     *   **IPC Base Directory:** `prompts/ipc/` (for future IPC components and general IPC file storage)
 
-C. **Discover and Load Add-on Components:**
+D. **Discover and Load Add-on Components:**
     1.  **Parse User Add-on Selections:**
         a.  Scan the `[[USER_ADDON_SELECTION]]` block from `Master_Prompt_Segment.txt`.
         b.  Identify lines beginning with `[x]` to extract the selected `addon_app_name`s (these are folder names).
@@ -47,16 +60,16 @@ C. **Discover and Load Add-on Components:**
     6.  **Handle Multiple Selected Primary Add-ons:** If `Loaded_Primary_Addon_AppNames` contains more than one app name, prepare a warning.
     7.  The collections are used in Section II.
 
-D. **Input Definition Files (Base IEP):**
+E. **Input Definition Files (Base IEP):**
     Loaded from `prompts/iep/Base_IEP.txt`. (Referenced in Section III.C.1).
 
-E. **Discover and Load Utility Components ("Utils"):**
+F. **Discover and Load Utility Components ("Utils"):**
     1.  Scan for subdirectories in `prompts/util/`. Each is a `util_app_name`.
     2.  Initialize `All_Available_Utils_Content_Map` (map for `util_app_name: content`).
     3.  Load `prompts/util/[util_app_name]/[util_app_name].txt` for each. Store if readable, else warn.
     4.  Utils are available for use by other components.
 
-F. **Discover and Load PromptApp Manifests:**
+G. **Discover and Load PromptApp Manifests:**
     1.  Initialize `Available_PromptApps_Manifest_Map` (empty map for `promptAppName: manifest_object`).
     2.  Scan `prompts/apps/` for subdirectories. Each is a `promptAppName`.
     3.  For each `promptAppName`:
@@ -67,7 +80,7 @@ F. **Discover and Load PromptApp Manifests:**
             ii. Store the valid manifest object in `Available_PromptApps_Manifest_Map` with `promptAppName` as key.
         d.  If manifest file is missing, unreadable, or JSON is invalid: Prepare a warning: "Warning: PromptApp '[promptAppName]' has a missing or invalid manifest at '[path_to_manifest]' and will be unavailable."
 
-G. **Parse User PromptApp Selection & Configuration:**
+H. **Parse User PromptApp Selection & Configuration:**
     1.  Initialize `Selected_PromptAppName`: null.
     2.  Initialize `Selected_App_Tasks_Ordered`: empty list.
     3.  Scan `Master_Prompt_Segment.txt` for the `[[USER_APP_SELECTION]]` block.


### PR DESCRIPTION
This commit introduces a new, streamlined method for you to invoke the MPS framework.

Key changes:
- You now prepare a single project instruction file (based on the Master_Prompt_Segment.txt template) that includes your high-level project request (wrapped in [[USER_PROJECT_REQUEST]] tags at the top) and all your MPS configurations.
- You invoke the AI system with a simple directive like `[[PROCESS_FRAMEWORK_INSTRUCTIONS FROM /path/to/your_file.txt]]`.
- Core_Planning_Instructions.txt updated to parse the [[USER_PROJECT_REQUEST]] block.
- Master_Prompt_Segment.txt updated with a new instructional header explaining this workflow.
- MPS_Usage_Guide.md extensively updated to document the new invocation method for both main MPS planning and direct utility invocation.
- HANDOFF_NOTES.md updated to reflect these changes.